### PR TITLE
Fix: show TWAP value even when the initial value is the most recent v…

### DIFF
--- a/lib/openbookTwap.ts
+++ b/lib/openbookTwap.ts
@@ -3,9 +3,14 @@ import { OPENBOOK_TWAP_PROGRAM_ID, QUOTE_LOTS } from './constants';
 import { TWAPOracle } from './types';
 
 export const calculateTWAP = (twapOracle?: TWAPOracle) => {
-  if (!twapOracle) return;
+  if (!twapOracle) return undefined;
+
+  // only the initial twap record is recorded, use initial value
+  if (twapOracle.lastUpdatedSlot.eq(twapOracle.initialSlot)) {
+    return twapOracle.observationAggregator.toNumber() * QUOTE_LOTS;
+  }
+
   const slotsPassed = twapOracle.lastUpdatedSlot.sub(twapOracle.initialSlot);
-  if (!slotsPassed.toNumber()) return;
   const twapValue = twapOracle.observationAggregator.div(slotsPassed);
   return twapValue.toNumber() * QUOTE_LOTS;
 };


### PR DESCRIPTION
Calculate and show TWAP even when the current value is the initial value. More details in issue https://github.com/metaDAOproject/meta-dao-frontend/issues/11.

I tried to follow contributor guidelines - please let me know if I missed something.