### PR TITLE
minor bugfix: link to fail market properly

### DIFF
--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -284,7 +284,9 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
                   <Text size="xs">
                     <a
                       href={generateExplorerLink(
-                        proposal?.account.openbookTwapPassMarket.toString()!,
+                        isPassMarket 
+                          ? proposal?.account.openbookTwapPassMarket.toString()!
+                          : proposal?.account.openbookTwapFailMarket.toString()!,
                         'account',
                       )}
                       target="blank"

--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -284,7 +284,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
                   <Text size="xs">
                     <a
                       href={generateExplorerLink(
-                        isPassMarket 
+                        isPassMarket
                           ? proposal?.account.openbookTwapPassMarket.toString()!
                           : proposal?.account.openbookTwapFailMarket.toString()!,
                         'account',


### PR DESCRIPTION
status quo is:
<img width="392" alt="image" src="https://github.com/metaDAOproject/meta-dao-frontend/assets/12001874/34293612-dee8-4c4e-b8f1-064fab41c0bc">
this links to the pass market despite the text. this pr fixes that. 