### PR TITLE
Caching and cleanup to improve performance and reduce RPC calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.format.semicolons": "insert"
+}

--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/core';
 import numeral from 'numeral';
 import { Icon12Hours, IconWallet, IconInfoCircle } from '@tabler/icons-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ConditionalMarketOrderBook } from './ConditionalMarketOrderBook';
 import { useAutocrat } from '../../contexts/AutocratContext';
 import { calculateTWAP, getLastObservedAndSlot } from '../../lib/openbookTwap';
@@ -26,7 +27,6 @@ import MarketTitle from './MarketTitle';
 import DisableNumberInputScroll from '../Utilities/DisableNumberInputScroll';
 import { useBalance } from '../../hooks/useBalance';
 import { useProvider } from '@/hooks/useProvider';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?: boolean; }) {
   const queryClient = useQueryClient();
@@ -59,7 +59,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
   );
 
   const { data: slotData } = useQuery({
-    queryKey: [`getSlot`],
+    queryKey: ['getSlot'],
     queryFn: () => provider.connection.getSlot(),
     staleTime: 30_000,
   });
@@ -344,7 +344,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
   }, [price]);
 
   useEffect(() => {
-    if ((!clusterTimestamp || clusterTimestamp === 0 && slot)) {
+    if (((!clusterTimestamp || clusterTimestamp === 0) && slot)) {
       getClusterTimestamp();
     }
   }, [slot]);

--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useMemo } from 'react';
 import {
   ActionIcon,
   Card,
@@ -26,8 +26,10 @@ import MarketTitle from './MarketTitle';
 import DisableNumberInputScroll from '../Utilities/DisableNumberInputScroll';
 import { useBalance } from '../../hooks/useBalance';
 import { useProvider } from '@/hooks/useProvider';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?: boolean }) {
+export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?: boolean; }) {
+  const queryClient = useQueryClient();
   const { daoState } = useAutocrat();
   const { proposal, orderBookObject, markets, isCranking, crankMarkets, placeOrder } =
     useProposal();
@@ -41,7 +43,6 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
   const [orderValue, setOrderValue] = useState<string>('0');
   const { generateExplorerLink } = useExplorerConfiguration();
   const [isPlacingOrder, setIsPlacingOrder] = useState(false);
-  const [slot, setSlot] = useState<number>(0);
   const [clusterTimestamp, setClusterTimestamp] = useState<number>(0);
   const [observedTimestamp, setObservedTimestamp] = useState<number>(0);
 
@@ -56,6 +57,13 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
       ? markets?.quoteVault.conditionalOnFinalizeTokenMint
       : markets?.quoteVault.conditionalOnRevertTokenMint,
   );
+
+  const { data: slotData } = useQuery({
+    queryKey: [`getSlot`],
+    queryFn: () => provider.connection.getSlot(),
+    staleTime: 30_000,
+  });
+  const slot = slotData ?? 0;
 
   if (!markets) return <></>;
   const passTwap = calculateTWAP(markets.passTwap.twapOracle);
@@ -156,7 +164,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
     return `${diff} seconds ago`;
   };
 
-  const lastObservedSlot = (): number => {
+  const lastObservedSlot = useMemo((): number => {
     if (passObservation && failObservation) {
       return (isPassMarket
         ? passObservation?.lastObservationSlot.toNumber()
@@ -164,7 +172,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
       );
     }
     return 0;
-  };
+  }, [isPassMarket, passObservation, failObservation]);
 
   const failMidPrice =
     (Number(orderBookObject?.failToB.topAsk) + Number(orderBookObject?.failToB.topBid)) / 2;
@@ -254,12 +262,6 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
     }
   }, [placeOrder, fetchBase, fetchQuote, amount, isLimitOrder, isPassMarket, isAskSide]);
 
-  const getSlot = async () => {
-    const _slot = await provider.connection.getSlot();
-    setSlot(_slot);
-    return _slot;
-  };
-
   const getObservableTwap = () => {
     if (isPassMarket) {
       if (passObservation) {
@@ -270,26 +272,26 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
           const evaluated = Math.min(passMidPrice, max_observation);
           return evaluated;
         }
-          const min_observation = (
-            (passObservation.lastObservationValue * (10_000 + 100)) / 10_000
-          );
-          const evaluated = Math.max(passMidPrice, min_observation);
-          return evaluated;
+        const min_observation = (
+          (passObservation.lastObservationValue * (10_000 + 100)) / 10_000
+        );
+        const evaluated = Math.max(passMidPrice, min_observation);
+        return evaluated;
       }
     } else if (failObservation) {
-        if (failMidPrice > failObservation.lastObservationValue) {
-          const max_observation = (
-            (failObservation.lastObservationValue * (10_000 + 100)) / 10_000
-          ) + 1;
-          const evaluated = Math.min(failMidPrice, max_observation);
-          return evaluated;
-        }
-          const min_observation = (
-            (failObservation.lastObservationValue * (10_000 + 100)) / 10_000
-          );
-          const evaluated = Math.max(failMidPrice, min_observation);
-          return evaluated;
+      if (failMidPrice > failObservation.lastObservationValue) {
+        const max_observation = (
+          (failObservation.lastObservationValue * (10_000 + 100)) / 10_000
+        ) + 1;
+        const evaluated = Math.min(failMidPrice, max_observation);
+        return evaluated;
       }
+      const min_observation = (
+        (failObservation.lastObservationValue * (10_000 + 100)) / 10_000
+      );
+      const evaluated = Math.max(failMidPrice, min_observation);
+      return evaluated;
+    }
   };
 
   const getTotalImpact = (): number => {
@@ -298,10 +300,10 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
       : failAggregateObservation);
     const twapObserved = getObservableTwap();
     if (twapObserved) {
-      const _slotDiffObserved = twapObserved * (slot - lastObservedSlot());
+      const _slotDiffObserved = twapObserved * (slot - lastObservedSlot);
       const newAggregate = (aggregateObservation + _slotDiffObserved);
       const startSlot = proposal?.account.slotEnqueued.toNumber();
-      const proposalTimeInSlots: number = lastObservedSlot() - startSlot;
+      const proposalTimeInSlots: number = lastObservedSlot - startSlot;
       const oldValue = aggregateObservation / proposalTimeInSlots;
       const newValue = newAggregate / proposalTimeInSlots;
       return (newValue - oldValue) / oldValue;
@@ -310,8 +312,19 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
   };
 
   const getClusterTimestamp = async () => {
-    const _clusterTimestamp = await provider.connection.getBlockTime(await getSlot());
-    const _observedTimestamp = await provider.connection.getBlockTime(lastObservedSlot());
+    let _clusterTimestamp: number = 0;
+    if (slot !== 0) {
+      _clusterTimestamp = await queryClient.fetchQuery({
+        queryKey: [`getBlockTime-${slot}`],
+        queryFn: () => provider.connection.getBlockTime(slot),
+        staleTime: 30_000,
+      });
+    }
+    const _observedTimestamp = await queryClient.fetchQuery({
+      queryKey: [`getBlockTime-${lastObservedSlot}`],
+      queryFn: () => provider.connection.getBlockTime(lastObservedSlot),
+      staleTime: 30_000,
+    });
     if (_clusterTimestamp) {
       setClusterTimestamp(_clusterTimestamp);
     }
@@ -331,13 +344,10 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
   }, [price]);
 
   useEffect(() => {
-    if (!slot || slot === 0) {
-      getSlot();
-    }
-    if ((!clusterTimestamp || clusterTimestamp === 0)) {
+    if ((!clusterTimestamp || clusterTimestamp === 0 && slot)) {
       getClusterTimestamp();
     }
-  }, []);
+  }, [slot]);
 
   return (
     <Card
@@ -385,25 +395,26 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
                     above the fail market{' '}
                     {daoState && failTwap
                       ? `(> ${numeral(
-                          (failTwap * (10000 + daoState.passThresholdBps)) / 10000,
-                        ).format(NUMERAL_FORMAT)})`
+                        (failTwap * (10000 + daoState.passThresholdBps)) / 10000,
+                      ).format(NUMERAL_FORMAT)})`
                       : null}
                     , the proposal will pass once the countdown ends.
                   </Text>
                   <Text>
                     Last observed price (for TWAP calculation) ${numeral(
-                    isPassMarket
-                    ? passObservation?.lastObservationValue
-                    : failObservation?.lastObservationValue).format(NUMERAL_FORMAT)}
+                      isPassMarket
+                        ? passObservation?.lastObservationValue
+                        : failObservation?.lastObservationValue).format(NUMERAL_FORMAT)}
                   </Text>
                   <Text size="xs">Last observed at
                     <br />
                     slot {
-                        isPassMarket
+                      isPassMarket
                         ? passObservation?.lastObservationSlot.toNumber()
                         : failObservation?.lastObservationSlot.toNumber()
-                      }{' '}
-                    | {slot - lastObservedSlot()} slots behind cluster
+                    }{' '}
+                    | {
+                      slot - lastObservedSlot} slots behind cluster
                     <br />
                     {(new Date((observedTimestamp * 1000))).toUTCString()}{' '}
                     | {timeSinceObservation()}
@@ -412,7 +423,7 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
                     (getTotalImpact() * 100).toLocaleString('fullwide', {
                       useGrouping: false,
                       maximumSignificantDigits: 20,
-                   })
+                    })
                   }%
                   </Text>
                   <Text c={isWinning()}>
@@ -540,12 +551,10 @@ export function ConditionalMarketCard({ isPassMarket = false }: { isPassMarket?:
                 <IconWallet height={12} />
                 <Text size="xs">
                   {isAskSide
-                    ? `${isPassMarket ? 'p' : 'f'}META ${
-                        numeral(baseBalance?.uiAmountString || 0).format(BASE_FORMAT) || ''
-                      }`
-                    : `${isPassMarket ? 'p' : 'f'}USDC $${
-                        numeral(quoteBalance?.uiAmountString || 0).format(NUMERAL_FORMAT) || ''
-                      }`}
+                    ? `${isPassMarket ? 'p' : 'f'}META ${numeral(baseBalance?.uiAmountString || 0).format(BASE_FORMAT) || ''
+                    }`
+                    : `${isPassMarket ? 'p' : 'f'}USDC $${numeral(quoteBalance?.uiAmountString || 0).format(NUMERAL_FORMAT) || ''
+                    }`}
                 </Text>
               </Group>
             ) : (

--- a/components/Proposals/ProposalCountdown.tsx
+++ b/components/Proposals/ProposalCountdown.tsx
@@ -1,0 +1,41 @@
+import { SLOTS_PER_10_SECS } from '@/lib/constants';
+import { Text } from '@mantine/core';
+import { useEffect, useMemo, useState } from 'react';
+
+export const ProposalCountdown: React.FC<{
+    remainingSlots: number | undefined;
+}> = ({ remainingSlots }) => {
+
+    const [secondsLeft, setSecondsLeft] = useState<number>(0);
+
+    const timeLeft = useMemo(() => {
+        if (!secondsLeft) return;
+        const seconds = secondsLeft;
+        const days = Math.floor(seconds / (60 * 60 * 24));
+        const hours = Math.floor((seconds % (60 * 60 * 24)) / (60 * 60));
+        const minutes = Math.floor((seconds % (60 * 60)) / 60);
+        const secLeft = Math.floor(seconds % 60);
+
+        return `${String(days).padStart(2, '0')}:${String(hours).padStart(2, '0')}:${String(
+            minutes,
+        ).padStart(2, '0')}:${String(secLeft).padStart(2, '0')}`;
+    }, [secondsLeft]);
+
+    useEffect(() => {
+        setSecondsLeft(((remainingSlots || 0) / SLOTS_PER_10_SECS) * 10);
+    }, [remainingSlots]);
+
+    useEffect(() => {
+        const interval = setInterval(
+            () => (secondsLeft && secondsLeft > 0 ? setSecondsLeft((old) => old - 1) : 0),
+            1000,
+        );
+
+        return () => clearInterval(interval);
+    });
+
+    return <>
+        {secondsLeft !== 0 && <Text fw="bold">Ends in {timeLeft}</Text>}
+    </>;
+
+};

--- a/components/Proposals/ProposalCountdown.tsx
+++ b/components/Proposals/ProposalCountdown.tsx
@@ -1,11 +1,10 @@
-import { SLOTS_PER_10_SECS } from '@/lib/constants';
 import { Text } from '@mantine/core';
 import { useEffect, useMemo, useState } from 'react';
+import { SLOTS_PER_10_SECS } from '@/lib/constants';
 
 export const ProposalCountdown: React.FC<{
     remainingSlots: number | undefined;
 }> = ({ remainingSlots }) => {
-
     const [secondsLeft, setSecondsLeft] = useState<number>(0);
 
     const timeLeft = useMemo(() => {
@@ -36,6 +35,5 @@ export const ProposalCountdown: React.FC<{
 
     return <>
         {secondsLeft !== 0 && <Text fw="bold">Ends in {timeLeft}</Text>}
-    </>;
-
+           </>;
 };

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -43,8 +43,10 @@ import { isClosableOrder, isEmptyOrder, isOpenOrder, isPartiallyFilled } from '.
 import { useOpenbookTwap } from '../../hooks/useOpenbookTwap';
 import { Proposal } from '../../lib/types';
 import { ProposalCountdown } from './ProposalCountdown';
+import { useQueryClient } from '@tanstack/react-query';
 
 export function ProposalDetailCard() {
+  const queryClient = useQueryClient();
   const wallet = useWallet();
   const { connection } = useConnection();
   const { fetchProposals, daoTreasury, daoState } = useAutocrat();
@@ -225,7 +227,12 @@ export function ProposalDetailCard() {
   useEffect(() => {
     if (lastSlot) return;
     async function fetchSlot() {
-      setLastSlot(await connection.getSlot());
+      const slot = await queryClient.fetchQuery({
+        queryKey: [`getSlot`],
+        queryFn: () => connection.getSlot(),
+        staleTime: 30_000,
+      });
+      setLastSlot(slot);
     }
 
     fetchSlot();

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -24,6 +24,7 @@ import { useMediaQuery } from '@mantine/hooks';
 import { TOKEN_PROGRAM_ID, getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { SystemProgram } from '@solana/web3.js';
 import { BN } from '@coral-xyz/anchor';
+import { useQueryClient } from '@tanstack/react-query';
 import { ProposalOrdersCard } from './ProposalOrdersCard';
 import { ConditionalMarketCard } from '../Markets/ConditionalMarketCard';
 import { JupSwapCard } from './JupSwapCard';
@@ -31,7 +32,6 @@ import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
 import { useAutocrat } from '@/contexts/AutocratContext';
 import { shortKey } from '@/lib/utils';
 import { StateBadge } from './StateBadge';
-import { SLOTS_PER_10_SECS } from '../../lib/constants';
 import { useTransactionSender } from '../../hooks/useTransactionSender';
 import { useConditionalVault } from '../../hooks/useConditionalVault';
 import { useProposal } from '@/contexts/ProposalContext';
@@ -43,7 +43,6 @@ import { isClosableOrder, isEmptyOrder, isOpenOrder, isPartiallyFilled } from '.
 import { useOpenbookTwap } from '../../hooks/useOpenbookTwap';
 import { Proposal } from '../../lib/types';
 import { ProposalCountdown } from './ProposalCountdown';
-import { useQueryClient } from '@tanstack/react-query';
 
 export function ProposalDetailCard() {
   const queryClient = useQueryClient();
@@ -228,7 +227,7 @@ export function ProposalDetailCard() {
     if (lastSlot) return;
     async function fetchSlot() {
       const slot = await queryClient.fetchQuery({
-        queryKey: [`getSlot`],
+        queryKey: ['getSlot'],
         queryFn: () => connection.getSlot(),
         staleTime: 30_000,
       });

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -42,6 +42,7 @@ import { useTokens } from '../../hooks/useTokens';
 import { isClosableOrder, isEmptyOrder, isOpenOrder, isPartiallyFilled } from '../../lib/openbook';
 import { useOpenbookTwap } from '../../hooks/useOpenbookTwap';
 import { Proposal } from '../../lib/types';
+import { ProposalCountdown } from './ProposalCountdown';
 
 export function ProposalDetailCard() {
   const wallet = useWallet();
@@ -58,7 +59,6 @@ export function ProposalDetailCard() {
 
   const { generateExplorerLink } = useExplorerConfiguration();
   const [lastSlot, setLastSlot] = useState<number>();
-  const [secondsLeft, setSecondsLeft] = useState<number>(0);
   const [isFinalizing, setIsFinalizing] = useState<boolean>(false);
   const [isClosing, setIsClosing] = useState<boolean>(false);
   const [isRedeeming, setIsRedeeming] = useState<boolean>(false);
@@ -78,32 +78,6 @@ export function ProposalDetailCard() {
 
     return Math.max(endSlot - lastSlot, 0);
   }, [proposal, lastSlot, daoState]);
-
-  useEffect(() => {
-    setSecondsLeft(((remainingSlots || 0) / SLOTS_PER_10_SECS) * 10);
-  }, [remainingSlots]);
-
-  useEffect(() => {
-    const interval = setInterval(
-      () => (secondsLeft && secondsLeft > 0 ? setSecondsLeft((old) => old - 1) : 0),
-      1000,
-    );
-
-    return () => clearInterval(interval);
-  });
-
-  const timeLeft = useMemo(() => {
-    if (!secondsLeft) return;
-    const seconds = secondsLeft;
-    const days = Math.floor(seconds / (60 * 60 * 24));
-    const hours = Math.floor((seconds % (60 * 60 * 24)) / (60 * 60));
-    const minutes = Math.floor((seconds % (60 * 60)) / 60);
-    const secLeft = Math.floor(seconds % 60);
-
-    return `${String(days).padStart(2, '0')}:${String(hours).padStart(2, '0')}:${String(
-      minutes,
-    ).padStart(2, '0')}:${String(secLeft).padStart(2, '0')}`;
-  }, [secondsLeft]);
 
   const handleFinalize = useCallback(async () => {
     if (!tokens?.meta || !daoTreasury || !wallet?.publicKey) return;
@@ -364,7 +338,7 @@ export function ProposalDetailCard() {
               </Stack>
             </Card>
           ) : null}
-          {secondsLeft !== 0 && <Text fw="bold">Ends in {timeLeft}</Text>}
+          <ProposalCountdown remainingSlots={remainingSlots} />
           <Group wrap="wrap" justify="space-between">
             <ExternalLink href={proposal.account.descriptionUrl} />
             <Text opacity={0.6} style={{ textAlign: 'right' }}>

--- a/components/Providers/Providers.tsx
+++ b/components/Providers/Providers.tsx
@@ -12,13 +12,13 @@ import {
 import { MoongateWalletAdapter } from '@moongate/moongate-adapter';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { Notifications } from '@mantine/notifications';
-import { theme } from '@/theme';
-import { useNetworkConfiguration } from '@/hooks/useNetworkConfiguration';
-import { AutocratProvider } from '@/contexts/AutocratContext';
 import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
+import { theme } from '@/theme';
+import { useNetworkConfiguration } from '@/hooks/useNetworkConfiguration';
+import { AutocratProvider } from '@/contexts/AutocratContext';
 
 const queryClient = new QueryClient();
 

--- a/components/Providers/Providers.tsx
+++ b/components/Providers/Providers.tsx
@@ -15,8 +15,14 @@ import { Notifications } from '@mantine/notifications';
 import { theme } from '@/theme';
 import { useNetworkConfiguration } from '@/hooks/useNetworkConfiguration';
 import { AutocratProvider } from '@/contexts/AutocratContext';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 
-export function Providers({ children }: { children: React.ReactNode }) {
+const queryClient = new QueryClient();
+
+export function Providers({ children }: { children: React.ReactNode; }) {
   const { endpoint } = useNetworkConfiguration();
 
   const wallets = useMemo(
@@ -39,7 +45,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       <ConnectionProvider endpoint={endpoint}>
         <WalletProvider wallets={wallets} onError={onError}>
           <WalletModalProvider>
-            <AutocratProvider>{children}</AutocratProvider>
+            <QueryClientProvider client={queryClient}>
+              <AutocratProvider>{children}</AutocratProvider>
+            </QueryClientProvider>
           </WalletModalProvider>
         </WalletProvider>
       </ConnectionProvider>

--- a/contexts/ProposalContext.tsx
+++ b/contexts/ProposalContext.tsx
@@ -172,7 +172,7 @@ export function ProposalProvider({
           openbook,
         );
 
-        setMarkets({
+        return {
           pass,
           passAsks,
           passBids,
@@ -183,14 +183,15 @@ export function ProposalProvider({
           failTwap,
           baseVault,
           quoteVault,
-        });
+        };
       };
 
-      await client.fetchQuery({
+      const marketsInfo = await client.fetchQuery({
         queryKey: [`fetchProposalMarketsInfo-${proposal?.publicKey}`],
         queryFn: () => fetchProposalMarketsInfo(),
         staleTime: 10_000,
       });
+      setMarkets(marketsInfo);
     }, 1000),
     [vaultProgram, openbook, openbookTwap, proposal, connection],
   );
@@ -203,7 +204,6 @@ export function ProposalProvider({
   const fetchOpenOrders = useCallback(
     debounce<[PublicKey]>(async (owner: PublicKey) => {
       const fetchProposalOpenOrders = async () => {
-
         if (!openbook || !proposal) {
           return;
         }
@@ -215,18 +215,17 @@ export function ProposalProvider({
           { memcmp: { offset: 8, bytes: owner.toBase58() } },
           { memcmp: { offset: 40, bytes: proposal.account.openbookFailMarket.toBase58() } },
         ]);
-        setOrders(
-          passOrders
-            .concat(failOrders)
-            .sort((a, b) => (a.account.accountNum < b.account.accountNum ? 1 : -1)),
-        );
+        return passOrders
+          .concat(failOrders)
+          .sort((a, b) => (a.account.accountNum < b.account.accountNum ? 1 : -1));
       };
 
-      await client.fetchQuery({
+      const orders = await client.fetchQuery({
         queryKey: [`fetchProposalOpenOrders-${proposal?.publicKey}`],
         queryFn: () => fetchProposalOpenOrders(),
         staleTime: 10_000,
       });
+      setOrders(orders ?? []);
     }, 1000),
     [openbook, proposal],
   );

--- a/contexts/ProposalContext.tsx
+++ b/contexts/ProposalContext.tsx
@@ -21,6 +21,7 @@ import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
 import { useTransactionSender } from '@/hooks/useTransactionSender';
 import { getLeafNodes } from '../lib/openbook';
 import { debounce } from '../lib/utils';
+import { useQueryClient } from '@tanstack/react-query';
 
 export interface ProposalInterface {
   proposal?: Proposal;
@@ -82,6 +83,7 @@ export function ProposalProvider({
   proposalNumber?: number | undefined;
   fromProposal?: ProposalAccountWithKey;
 }) {
+  const client = useQueryClient();
   const { autocratProgram, dao, daoState, daoTreasury, openbook, openbookTwap, proposals } =
     useAutocrat();
   const { connection } = useConnection();
@@ -114,72 +116,80 @@ export function ProposalProvider({
 
   const fetchMarketsInfo = useCallback(
     debounce(async () => {
-      if (!proposal || !openbook || !openbookTwap || !openbookTwap.views || !connection) {
-        return;
-      }
-      const accountInfos = await connection.getMultipleAccountsInfo([
-        proposal.account.openbookPassMarket,
-        proposal.account.openbookFailMarket,
-        proposal.account.openbookTwapPassMarket,
-        proposal.account.openbookTwapFailMarket,
-        proposal.account.baseVault,
-        proposal.account.quoteVault,
-      ]);
-      if (!accountInfos || accountInfos.indexOf(null) >= 0) return;
+      const fetchProposalMarketsInfo = async () => {
+        if (!proposal || !openbook || !openbookTwap || !openbookTwap.views || !connection) {
+          return;
+        }
+        const accountInfos = await connection.getMultipleAccountsInfo([
+          proposal.account.openbookPassMarket,
+          proposal.account.openbookFailMarket,
+          proposal.account.openbookTwapPassMarket,
+          proposal.account.openbookTwapFailMarket,
+          proposal.account.baseVault,
+          proposal.account.quoteVault,
+        ]);
+        if (!accountInfos || accountInfos.indexOf(null) >= 0) return;
 
-      const pass = await openbook.coder.accounts.decode('market', accountInfos[0]!.data);
-      const fail = await openbook.coder.accounts.decode('market', accountInfos[1]!.data);
-      const passTwap = await openbookTwap.coder.accounts.decodeUnchecked(
-        'TWAPMarket',
-        accountInfos[2]!.data,
-      );
-      const failTwap = await openbookTwap.coder.accounts.decodeUnchecked(
-        'TWAPMarket',
-        accountInfos[3]!.data,
-      );
-      const baseVault = await vaultProgram.coder.accounts.decode(
-        'conditionalVault',
-        accountInfos[4]!.data,
-      );
-      const quoteVault = await vaultProgram.coder.accounts.decode(
-        'conditionalVault',
-        accountInfos[5]!.data,
-      );
+        const pass = await openbook.coder.accounts.decode('market', accountInfos[0]!.data);
+        const fail = await openbook.coder.accounts.decode('market', accountInfos[1]!.data);
+        const passTwap = await openbookTwap.coder.accounts.decodeUnchecked(
+          'TWAPMarket',
+          accountInfos[2]!.data,
+        );
+        const failTwap = await openbookTwap.coder.accounts.decodeUnchecked(
+          'TWAPMarket',
+          accountInfos[3]!.data,
+        );
+        const baseVault = await vaultProgram.coder.accounts.decode(
+          'conditionalVault',
+          accountInfos[4]!.data,
+        );
+        const quoteVault = await vaultProgram.coder.accounts.decode(
+          'conditionalVault',
+          accountInfos[5]!.data,
+        );
 
-      const bookAccountInfos = await connection.getMultipleAccountsInfo([
-        pass.asks,
-        pass.bids,
-        fail.asks,
-        fail.bids,
-      ]);
-      const passAsks = getLeafNodes(
-        await openbook.coder.accounts.decode('bookSide', bookAccountInfos[0]!.data),
-        openbook,
-      );
-      const passBids = getLeafNodes(
-        await openbook.coder.accounts.decode('bookSide', bookAccountInfos[1]!.data),
-        openbook,
-      );
-      const failAsks = getLeafNodes(
-        await openbook.coder.accounts.decode('bookSide', bookAccountInfos[2]!.data),
-        openbook,
-      );
-      const failBids = getLeafNodes(
-        await openbook.coder.accounts.decode('bookSide', bookAccountInfos[3]!.data),
-        openbook,
-      );
+        const bookAccountInfos = await connection.getMultipleAccountsInfo([
+          pass.asks,
+          pass.bids,
+          fail.asks,
+          fail.bids,
+        ]);
+        const passAsks = getLeafNodes(
+          await openbook.coder.accounts.decode('bookSide', bookAccountInfos[0]!.data),
+          openbook,
+        );
+        const passBids = getLeafNodes(
+          await openbook.coder.accounts.decode('bookSide', bookAccountInfos[1]!.data),
+          openbook,
+        );
+        const failAsks = getLeafNodes(
+          await openbook.coder.accounts.decode('bookSide', bookAccountInfos[2]!.data),
+          openbook,
+        );
+        const failBids = getLeafNodes(
+          await openbook.coder.accounts.decode('bookSide', bookAccountInfos[3]!.data),
+          openbook,
+        );
 
-      setMarkets({
-        pass,
-        passAsks,
-        passBids,
-        fail,
-        failAsks,
-        failBids,
-        passTwap,
-        failTwap,
-        baseVault,
-        quoteVault,
+        setMarkets({
+          pass,
+          passAsks,
+          passBids,
+          fail,
+          failAsks,
+          failBids,
+          passTwap,
+          failTwap,
+          baseVault,
+          quoteVault,
+        });
+      };
+
+      await client.fetchQuery({
+        queryKey: [`fetchProposalMarketsInfo-${proposal?.publicKey}`],
+        queryFn: () => fetchProposalMarketsInfo(),
+        staleTime: 10_000,
       });
     }, 1000),
     [vaultProgram, openbook, openbookTwap, proposal, connection],
@@ -192,22 +202,31 @@ export function ProposalProvider({
 
   const fetchOpenOrders = useCallback(
     debounce<[PublicKey]>(async (owner: PublicKey) => {
-      if (!openbook || !proposal) {
-        return;
-      }
-      const passOrders = await openbook.account.openOrdersAccount.all([
-        { memcmp: { offset: 8, bytes: owner.toBase58() } },
-        { memcmp: { offset: 40, bytes: proposal.account.openbookPassMarket.toBase58() } },
-      ]);
-      const failOrders = await openbook.account.openOrdersAccount.all([
-        { memcmp: { offset: 8, bytes: owner.toBase58() } },
-        { memcmp: { offset: 40, bytes: proposal.account.openbookFailMarket.toBase58() } },
-      ]);
-      setOrders(
-        passOrders
-          .concat(failOrders)
-          .sort((a, b) => (a.account.accountNum < b.account.accountNum ? 1 : -1)),
-      );
+      const fetchProposalOpenOrders = async () => {
+
+        if (!openbook || !proposal) {
+          return;
+        }
+        const passOrders = await openbook.account.openOrdersAccount.all([
+          { memcmp: { offset: 8, bytes: owner.toBase58() } },
+          { memcmp: { offset: 40, bytes: proposal.account.openbookPassMarket.toBase58() } },
+        ]);
+        const failOrders = await openbook.account.openOrdersAccount.all([
+          { memcmp: { offset: 8, bytes: owner.toBase58() } },
+          { memcmp: { offset: 40, bytes: proposal.account.openbookFailMarket.toBase58() } },
+        ]);
+        setOrders(
+          passOrders
+            .concat(failOrders)
+            .sort((a, b) => (a.account.accountNum < b.account.accountNum ? 1 : -1)),
+        );
+      };
+
+      await client.fetchQuery({
+        queryKey: [`fetchProposalOpenOrders-${proposal?.publicKey}`],
+        queryFn: () => fetchProposalOpenOrders(),
+        staleTime: 10_000,
+      });
     }, 1000),
     [openbook, proposal],
   );
@@ -263,12 +282,17 @@ export function ProposalProvider({
       const metaTokenAccount = getAssociatedTokenAddressSync(metaMint, wallet.publicKey, false);
 
       try {
-        metaBalance = await connection.getTokenAccountBalance(metaTokenAccount);
+        metaBalance = await client.fetchQuery({
+          queryKey: [`getTokenAccountBalance-${metaTokenAccount.toString()}-undefined`],
+          queryFn: () => connection.getTokenAccountBalance(metaTokenAccount),
+          staleTime: 10_000,
+        });
       } catch (err) {
         console.error('unable to fetch balance for META token account');
       }
       try {
         if (fromBase) {
+          // WHY do we fetch these but do nothing with result?
           await connection.getTokenAccountBalance(userBasePass);
         } else {
           await connection.getTokenAccountBalance(userQuotePass);

--- a/contexts/ProposalContext.tsx
+++ b/contexts/ProposalContext.tsx
@@ -223,7 +223,7 @@ export function ProposalProvider({
       const orders = await client.fetchQuery({
         queryKey: [`fetchProposalOpenOrders-${proposal?.publicKey}`],
         queryFn: () => fetchProposalOpenOrders(),
-        staleTime: 10_000,
+        staleTime: 1_000,
       });
       setOrders(orders ?? []);
     }, 1000),

--- a/hooks/useAutocratDebug.ts
+++ b/hooks/useAutocratDebug.ts
@@ -8,7 +8,7 @@ export function useAutocratDebug() {
   const wallet = useWallet();
   const { connection } = useConnection();
   const { tokens } = useTokens();
-  const { dao, daoState, daoTreasury, autocratProgram: program, fetchState } = useAutocrat();
+  const { dao, daoState, daoTreasury, autocratProgram: program } = useAutocrat();
 
   const initializeDao = useCallback(async () => {
     if (
@@ -45,8 +45,7 @@ export function useAutocratDebug() {
     await Promise.all(
       signedTxs.map((tx) => connection.sendRawTransaction(tx.serialize(), { skipPreflight: true })),
     );
-    fetchState();
-  }, [program, dao, wallet, tokens, connection, fetchState, program]);
+  }, [program, dao, wallet, tokens, connection, program]);
 
-  return { program, dao, daoTreasury, daoState, initializeDao, fetchState };
+  return { program, dao, daoTreasury, daoState, initializeDao, };
 }

--- a/hooks/useInitializeProposal.ts
+++ b/hooks/useInitializeProposal.ts
@@ -20,7 +20,6 @@ export function useInitializeProposal() {
     dao,
     daoTreasury,
     daoState,
-    fetchState,
     fetchProposals,
   } = useAutocrat();
   const wallet = useWallet();
@@ -28,9 +27,9 @@ export function useInitializeProposal() {
   const { program: openbookTwap } = useOpenbookTwap();
   const { tokens } = useTokens();
   const baseNonce: BN = new BN(daoState?.proposalCount || 0);
-  const [vaults, setVaults] = useState<{ base: InitializedVault; quote: InitializedVault }>();
-  const [markets, setMarkets] = useState<{ pass: Keypair; fail: Keypair }>();
-  const [twaps, setTwaps] = useState<{ pass: PublicKey; fail: PublicKey }>();
+  const [vaults, setVaults] = useState<{ base: InitializedVault; quote: InitializedVault; }>();
+  const [markets, setMarkets] = useState<{ pass: Keypair; fail: Keypair; }>();
+  const [twaps, setTwaps] = useState<{ pass: PublicKey; fail: PublicKey; }>();
 
   useEffect(() => {
     const f = async () => {
@@ -71,7 +70,6 @@ export function useInitializeProposal() {
 
     await sender.send([vaultTx]);
     setVaults({ base: baseVault, quote: quoteVault });
-    fetchState();
     fetchProposals();
   }, [daoTreasury, tokens]);
 
@@ -168,7 +166,6 @@ export function useInitializeProposal() {
       );
     }
     setMarkets({ pass: openbookPassMarketKP, fail: openbookFailMarketKP });
-    fetchState();
     fetchProposals();
   }, [dao, program, connection, wallet, tokens, vaults]);
 
@@ -238,7 +235,6 @@ export function useInitializeProposal() {
       );
     }
     setTwaps({ pass: openbookTwapPassMarket, fail: openbookTwapFailMarket });
-    fetchState();
     fetchProposals();
   }, [dao, program, connection, wallet, tokens]);
 
@@ -304,7 +300,6 @@ export function useInitializeProposal() {
           'confirmed',
         );
       }
-      fetchState();
       fetchProposals();
     },
     [dao, program, connection, wallet, tokens],

--- a/hooks/useNetworkConfiguration.ts
+++ b/hooks/useNetworkConfiguration.ts
@@ -25,9 +25,9 @@ export function useNetworkConfiguration() {
   const endpoint = useMemo(() => {
     switch (network) {
       case Networks.Mainnet:
-        return 'https://mainnet.helius-rpc.com/?api-key=3f6d553e-de08-4fb9-9212-5d87bbfd1328';
+        return 'https://rpc-proxy.themetadao-org.workers.dev/';
       case Networks.Devnet:
-        return 'https://devnet.helius-rpc.com/?api-key=3f6d553e-de08-4fb9-9212-5d87bbfd1328';
+        return 'https://netty-8ka8l7-fast-devnet.helius-rpc.com/';
       case Networks.Localnet:
         return 'http://127.0.0.1:8899';
       case Networks.Custom:

--- a/hooks/useTokenAmount.ts
+++ b/hooks/useTokenAmount.ts
@@ -26,7 +26,8 @@ export function useTokenAmount(mint?: PublicKey, owner?: PublicKey) {
         uiAmount: 0.0,
       };
       try {
-        setAmount((await connection.getTokenAccountBalance(account)).value);
+        const tokenBalance = await connection.getTokenAccountBalance(account);
+        setAmount(tokenBalance.value);
       } catch (err) {
         console.error(
           `Error with this account fetch ${account.toString()} (owner: ${(

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@solana/wallet-adapter-wallets": "^0.19.23",
         "@solana/web3.js": "^1.87.2",
         "@tabler/icons-react": "^2.20.0",
+        "@tanstack/react-query": "^5.24.1",
         "next": "^13.5.6",
         "numeral": "^2.0.6",
         "react": "18.2.0",
@@ -10475,6 +10476,30 @@
       },
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.24.1.tgz",
+      "integrity": "sha512-DZ6Nx9p7BhjkG50ayJ+MKPgff+lMeol7QYXkvuU5jr2ryW/4ok5eanaS9W5eooA4xN0A/GPHdLGOZGzArgf5Cg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.24.1.tgz",
+      "integrity": "sha512-4+09JEdO4d6+Gc8Y/g2M/MuxDK5IY0QV8+2wL2304wPKJgJ54cBbULd3nciJ5uvh/as8rrxx6s0mtIwpRuGd1g==",
+      "dependencies": {
+        "@tanstack/query-core": "5.24.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.23",
     "@solana/web3.js": "^1.87.2",
     "@tabler/icons-react": "^2.20.0",
+    "@tanstack/react-query": "^5.24.1",
     "next": "^13.5.6",
     "numeral": "^2.0.6",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "jest": "jest",
     "jest:watch": "jest --watch",
     "prettier:check": "prettier --check \"**/*.{ts,tsx}\"",


### PR DESCRIPTION
- Adding `react-query` to enable caching on a variety of network calls.
- Remove the constant 1 second re-rendering of the whole ProposalDetailCard(most of proposal page)
- Add new RPC nodes with more secure URL
- clean up excessive fetch calls causing other network calls
Helps to address the underlying issue from: https://github.com/metaDAOproject/meta-dao-frontend/issues/1

@R-K-H 