### PR TITLE
User Open Orders update from websocket instead of manual fetching at page load

### DIFF
--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -286,8 +286,9 @@ export function ConditionalMarketCard({
         const relevantMint = isAskSide
           ? marketAccount.account.baseMint
           : marketAccount.account.quoteMint;
+        const balanceChange = isAskSide ? amount : _orderPrice();
         setBalanceByMint(relevantMint, (oldBalance) => {
-          const newAmount = (oldBalance.uiAmount ?? 0) - amount;
+          const newAmount = (oldBalance.uiAmount ?? 0) - balanceChange;
           return {
             ...oldBalance,
             amount: newAmount.toString(),

--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -300,7 +300,7 @@ export function ConditionalMarketCard({
     } finally {
       setIsPlacingOrder(false);
     }
-  }, [placeOrder, amount, isLimitOrder, isPassMarket, isAskSide]);
+  }, [placeOrder, amount, isLimitOrder, isPassMarket, isAskSide, price]);
 
   const getObservableTwap = () => {
     if (isPassMarket) {

--- a/components/Markets/ConditionalMarketCard.tsx
+++ b/components/Markets/ConditionalMarketCard.tsx
@@ -100,7 +100,11 @@ export function ConditionalMarketCard({
 
   const updateOrderValue = () => {
     if (!Number.isNaN(amount) && !Number.isNaN(+price)) {
-      const _price = parseFloat((+price * amount).toString()).toFixed(2);
+      const formatter = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+      const _price = formatter.format(parseFloat((+price * amount).toString()));
       setOrderValue(_price);
     } else {
       setOrderValue('0');
@@ -600,7 +604,7 @@ export function ConditionalMarketCard({
               <Text> </Text>
             )}
             <>
-              <Text size="xs">Total Order Value ${orderValue}</Text>
+              <Text size="xs">Total Order Value {orderValue}</Text>
             </>
           </Group>
           <Grid>

--- a/components/Orders/ProposalOpenOrderRow.tsx
+++ b/components/Orders/ProposalOpenOrderRow.tsx
@@ -28,6 +28,7 @@ import { useProposal } from '@/contexts/ProposalContext';
 import { isBid, isPartiallyFilled, isPass } from '@/lib/openbook';
 import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
 import { useBalances } from '@/contexts/BalancesContext';
+import { BN } from '@coral-xyz/anchor';
 
 export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKey }) {
   const theme = useMantineTheme();
@@ -61,7 +62,10 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
       setIsCanceling(true);
       const txsSent = await cancelAndSettleOrder(order, marketAccount.publicKey);
       if (txsSent && txsSent.length > 0) {
-        const balanceChange = isBidSide ? order.account.openOrders[0].lockedPrice : balance;
+        const quoteLots = new BN(10 ** marketAccount.account.quoteDecimals);
+        const balanceChange = isBidSide
+          ? (order.account.openOrders[0].lockedPrice / quoteLots) * 100
+          : balance;
         const relevantMint = isBidSide
           ? marketAccount.account.quoteMint
           : marketAccount.account.baseMint;

--- a/components/Orders/ProposalOpenOrderRow.tsx
+++ b/components/Orders/ProposalOpenOrderRow.tsx
@@ -19,6 +19,7 @@ import {
   IconPencilCancel,
   IconCheck,
 } from '@tabler/icons-react';
+import { BN } from '@coral-xyz/anchor';
 import { OpenOrdersAccountWithKey } from '@/lib/types';
 import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
 import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
@@ -28,7 +29,6 @@ import { useProposal } from '@/contexts/ProposalContext';
 import { isBid, isPartiallyFilled, isPass } from '@/lib/openbook';
 import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
 import { useBalances } from '@/contexts/BalancesContext';
-import { BN } from '@coral-xyz/anchor';
 
 export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKey }) {
   const theme = useMantineTheme();

--- a/components/Orders/ProposalOpenOrderRow.tsx
+++ b/components/Orders/ProposalOpenOrderRow.tsx
@@ -61,11 +61,12 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
       setIsCanceling(true);
       const txsSent = await cancelAndSettleOrder(order, marketAccount.publicKey);
       if (txsSent && txsSent.length > 0) {
+        const balanceChange = isBidSide ? order.account.openOrders[0].lockedPrice : balance;
         const relevantMint = isBidSide
           ? marketAccount.account.quoteMint
           : marketAccount.account.baseMint;
         setBalanceByMint(relevantMint, (oldBalance) => {
-          const newAmount = oldBalance.uiAmount + balance.toNumber();
+          const newAmount = oldBalance.uiAmount + balanceChange.toNumber();
           return {
             ...oldBalance,
             amount: newAmount.toString(),

--- a/components/Orders/ProposalOpenOrderRow.tsx
+++ b/components/Orders/ProposalOpenOrderRow.tsx
@@ -35,7 +35,7 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
   const wallet = useWallet();
   const { generateExplorerLink } = useExplorerConfiguration();
   const { proposal } = useProposal();
-  const { markets, fetchOpenOrders, cancelAndSettleOrder } = useProposalMarkets();
+  const { markets, cancelAndSettleOrder } = useProposalMarkets();
   const { settleFundsTransactions, editOrderTransactions } = useOpenbookTwap();
   const { setBalanceByMint } = useBalances();
   const isBidSide = isBid(order);
@@ -79,7 +79,7 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
     } finally {
       setIsCanceling(false);
     }
-  }, [order, proposal, markets, wallet.publicKey, cancelAndSettleOrder, fetchOpenOrders, sender]);
+  }, [order, proposal, markets, wallet.publicKey, cancelAndSettleOrder, sender]);
 
   const handleEdit = useCallback(async () => {
     if (!proposal || !markets || !editingOrder) return;
@@ -127,7 +127,6 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
       //     };
       //   });
       // }
-      await fetchOpenOrders(wallet.publicKey);
       setEditingOrder(undefined);
     } finally {
       setIsEditing(false);
@@ -140,7 +139,6 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
     editedSize,
     editedPrice,
     editOrderTransactions,
-    fetchOpenOrders,
     sender,
   ]);
 
@@ -166,6 +164,10 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
       setIsSettling(false);
     }
   }, [order, proposal, settleFundsTransactions]);
+
+  const price = numeral(order.account.openOrders[0].lockedPrice * QUOTE_LOTS).format(
+    NUMERAL_FORMAT,
+  );
 
   return (
     <Table.Tr key={order.publicKey.toString()}>
@@ -216,9 +218,7 @@ export function ProposalOpenOrderRow({ order }: { order: OpenOrdersAccountWithKe
           <Input
             w="5rem"
             variant="filled"
-            defaultValue={numeral(order.account.openOrders[0].lockedPrice * QUOTE_LOTS).format(
-              NUMERAL_FORMAT,
-            )}
+            defaultValue={price}
             onChange={(e) => setEditedPrice(Number(e.target.value))}
           />
         ) : (

--- a/components/Orders/ProposalOpenOrdersTab.tsx
+++ b/components/Orders/ProposalOpenOrdersTab.tsx
@@ -13,9 +13,9 @@ import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
 
 const headers = ['Order ID', 'Market', 'Status', 'Size', 'Price', 'Notional', 'Actions'];
 
-export function ProposalOpenOrdersTab({ orders }: { orders: OpenOrdersAccountWithKey[]; }) {
+export function ProposalOpenOrdersTab({ orders }: { orders: OpenOrdersAccountWithKey[] }) {
   const { isCranking, crankMarkets, proposal } = useProposal();
-  const { markets, fetchOpenOrders } = useProposalMarkets();
+  const { markets } = useProposalMarkets();
   const sender = useTransactionSender();
   const wallet = useWallet();
   const { cancelOrderTransactions, settleFundsTransactions } = useOpenbookTwap();
@@ -45,14 +45,12 @@ export function ProposalOpenOrdersTab({ orders }: { orders: OpenOrdersAccountWit
       setIsCanceling(true);
       // Filtered undefined already
       await sender.send(txs);
-      // We already return above if the wallet doesn't have a public key
-      await fetchOpenOrders(wallet.publicKey!);
     } catch (err) {
       console.error(err);
     } finally {
       setIsCanceling(false);
     }
-  }, [proposal, markets, wallet.publicKey, cancelOrderTransactions, fetchOpenOrders, sender]);
+  }, [proposal, markets, wallet.publicKey, cancelOrderTransactions, sender]);
 
   const handleSettleAllFunds = useCallback(async () => {
     if (!proposal || !markets) return;

--- a/components/Orders/ProposalUnsettledOrderRow.tsx
+++ b/components/Orders/ProposalUnsettledOrderRow.tsx
@@ -12,6 +12,7 @@ import {
 import { useWallet } from '@solana/wallet-adapter-react';
 import { Icon3dRotate, IconWriting, Icon12Hours, IconAssemblyOff } from '@tabler/icons-react';
 import { BN } from '@coral-xyz/anchor';
+import { useQueryClient } from '@tanstack/react-query';
 import { OpenOrdersAccountWithKey } from '@/lib/types';
 import { useExplorerConfiguration } from '@/hooks/useExplorerConfiguration';
 import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
@@ -21,7 +22,6 @@ import { useProposal } from '@/contexts/ProposalContext';
 import { isBid, isPartiallyFilled, isPass } from '@/lib/openbook';
 import { useBalances } from '../../contexts/BalancesContext';
 import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
-import { useQueryClient } from '@tanstack/react-query';
 
 export function ProposalUnsettledOrderRow({ order }: { order: OpenOrdersAccountWithKey }) {
   const queryClient = useQueryClient();

--- a/components/Orders/ProposalUnsettledOrderRow.tsx
+++ b/components/Orders/ProposalUnsettledOrderRow.tsx
@@ -70,8 +70,9 @@ export function ProposalUnsettledOrderRow({ order }: { order: OpenOrdersAccountW
       const [relevantMint, relevantBalance] = isBidSide
         ? [marketAccount.account.quoteMint, quoteBalance]
         : [marketAccount.account.baseMint, baseBalance];
+      const balanceChange = isBidSide ? order.account.openOrders[0].lockedPrice : relevantBalance;
       setBalanceByMint(relevantMint, (oldBalance) => {
-        const newAmount = (oldBalance.uiAmount ?? 0) + relevantBalance;
+        const newAmount = (oldBalance.uiAmount ?? 0) + balanceChange;
         return {
           ...oldBalance,
           amount: newAmount.toString(),

--- a/components/Orders/ProposalUnsettledOrderRow.tsx
+++ b/components/Orders/ProposalUnsettledOrderRow.tsx
@@ -129,7 +129,7 @@ export function ProposalUnsettledOrderRow({ order }: { order: OpenOrdersAccountW
       </Table.Td>
       <Table.Td>
         <Stack gap={0}>
-          <Text>{`${baseBalance} ${isPass(order, proposal) ? `pMETA` : 'fMETA'}`}</Text>
+          <Text>{`${baseBalance} ${isPass(order, proposal) ? 'pMETA' : 'fMETA'}`}</Text>
           <Text>{`${quoteBalance} ${isPass(order, proposal) ? 'pUSDC' : 'fUSDC'}`}</Text>
         </Stack>
       </Table.Td>

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -40,7 +40,7 @@ import ExternalLink from '../ExternalLink';
 import MarketsBalances from './MarketsBalances';
 import classes from '../../app/globals.module.css';
 import { useTokens } from '../../hooks/useTokens';
-import { isClosableOrder, isEmptyOrder, isOpenOrder, isPartiallyFilled } from '../../lib/openbook';
+import { isClosableOrder, isPartiallyFilled } from '../../lib/openbook';
 import { useOpenbookTwap } from '../../hooks/useOpenbookTwap';
 import { Proposal } from '../../lib/types';
 import { ProposalCountdown } from './ProposalCountdown';

--- a/components/Proposals/ProposalDetailCard.tsx
+++ b/components/Proposals/ProposalDetailCard.tsx
@@ -55,8 +55,8 @@ export function ProposalDetailCard() {
   const { tokens } = useTokens();
   const { proposal, finalizeProposalTransactions } = useProposal();
   const {
-    orders,
-    fetchOpenOrders,
+    openOrders,
+    unsettledOrders,
     markets,
     passAsks,
     passBids,
@@ -146,21 +146,19 @@ export function ProposalDetailCard() {
   }, [tokens, daoTreasury, sender, finalizeProposalTransactions, fetchProposals]);
 
   const handleCloseOrders = useCallback(async () => {
-    if (!proposal || !orders || !markets || !wallet.publicKey) {
+    if (!proposal || !openOrders || !markets || !wallet.publicKey) {
       return;
     }
 
-    const openOrders = orders.filter((order) => isOpenOrder(order, markets));
     // TODO: also handle uncranked orders
     // const uncrankedOrders = orders.filter((order) => isCompletedOrder(order, markets));
-    const unsettledOrders = orders.filter((order) => isEmptyOrder(order));
 
-    const ordersToSettle = unsettledOrders.filter((order) => isPartiallyFilled(order));
-    const ordersToClose = unsettledOrders.filter((order) => isClosableOrder(order));
+    const ordersToSettle = unsettledOrders?.filter((order) => isPartiallyFilled(order)) ?? [];
+    const ordersToClose = unsettledOrders?.filter((order) => isClosableOrder(order)) ?? [];
 
     const cancelOpenOrdersTxs = (
       await Promise.all(
-        openOrders.map((order) =>
+        (openOrders ?? []).map((order) =>
           cancelOrderTransactions(
             new BN(order.account.accountNum),
             proposal.account.openbookPassMarket.equals(order.account.market)
@@ -173,7 +171,7 @@ export function ProposalDetailCard() {
 
     const settleOrdersTxs = (
       await Promise.all(
-        openOrders.concat(ordersToSettle).map((order) => {
+        (openOrders ?? []).concat(ordersToSettle).map((order) => {
           const pass = order.account.market.equals(proposal.account.openbookPassMarket);
           return settleFundsTransactions(
             order.account.accountNum,
@@ -189,7 +187,7 @@ export function ProposalDetailCard() {
 
     const closeOrdersTxs = (
       await Promise.all(
-        openOrders
+        (openOrders ?? [])
           .concat(ordersToSettle)
           .concat(ordersToClose)
           .map((order) => closeOpenOrdersAccountTransactions(new BN(order.account.accountNum))),
@@ -202,18 +200,9 @@ export function ProposalDetailCard() {
         [cancelOpenOrdersTxs, settleOrdersTxs, closeOrdersTxs].filter((set) => set.length !== 0),
       );
     } finally {
-      fetchOpenOrders(wallet.publicKey);
       setIsClosing(false);
     }
-  }, [
-    orders,
-    markets,
-    proposal,
-    sender,
-    wallet.publicKey,
-    cancelOrderTransactions,
-    fetchOpenOrders,
-  ]);
+  }, [openOrders, markets, proposal, sender, wallet.publicKey, cancelOrderTransactions]);
 
   const handleRedeem = useCallback(async () => {
     if (!markets || !proposal) return;
@@ -410,12 +399,12 @@ export function ProposalDetailCard() {
           <>
             <Button
               loading={isClosing}
-              disabled={(orders?.length || 0) === 0}
+              disabled={(openOrders?.length || 0) === 0}
               onClick={handleCloseOrders}
             >
               Close remaining orders
             </Button>
-            {(orders?.length || 0) === 0 ? (
+            {(openOrders?.length || 0) === 0 ? (
               <Button color="green" loading={isRedeeming} onClick={handleRedeem}>
                 Redeem
               </Button>

--- a/components/Proposals/ProposalOrdersCard.tsx
+++ b/components/Proposals/ProposalOrdersCard.tsx
@@ -14,8 +14,10 @@ import { ProposalUnsettledOrdersTab } from '@/components/Orders/ProposalUnsettle
 import { ProposalUncrankedOrdersTab } from '@/components/Orders/ProposalUncrankedOrdersTab';
 import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
 import { useOpenbook } from '@/hooks/useOpenbook';
+import { useCallback } from 'react';
 
 export function ProposalOrdersCard() {
+  const { publicKey: owner } = useWallet();
   const { proposal } = useProposal();
   const {
     markets,
@@ -23,6 +25,7 @@ export function ProposalOrdersCard() {
     unsettledOrders,
     uncrankedOrders: unCrankedOrders,
     refreshUserOpenOrders,
+    fetchNonOpenOrders,
   } = useProposalMarkets();
   const { program: openBookClient } = useOpenbook();
 
@@ -40,6 +43,15 @@ export function ProposalOrdersCard() {
       );
     }
   };
+
+  const onTabChange = useCallback(
+    (event: string | null) => {
+      if ((event === 'unsettled' || event === 'uncranked') && owner) {
+        fetchNonOpenOrders(owner, openBookClient.program, proposal, markets);
+      }
+    },
+    [!!owner],
+  );
 
   return !proposal || !markets || !openOrders ? (
     <Group justify="center" w="100%" h="100%">
@@ -77,7 +89,7 @@ export function ProposalOrdersCard() {
         </Group>
         <Stack justify="start" align="start" />
       </Stack>
-      <Tabs defaultValue="open">
+      <Tabs onChange={onTabChange} defaultValue="open">
         <Tabs.List>
           <Tabs.Tab value="open">Open</Tabs.Tab>
           <Tabs.Tab value="uncranked">Uncranked</Tabs.Tab>

--- a/components/Proposals/ProposalOrdersCard.tsx
+++ b/components/Proposals/ProposalOrdersCard.tsx
@@ -1,20 +1,14 @@
 import { ActionIcon, Group, Loader, Stack, Tabs, Text } from '@mantine/core';
 import { useWallet } from '@solana/wallet-adapter-react';
 import { IconRefresh } from '@tabler/icons-react';
-import { useProposal } from '@/contexts/ProposalContext';
-import {
-  isCompletedOrder,
-  isEmptyOrder,
-  isOpenOrder,
-  totalMetaInOrder,
-  totalUsdcInOrder,
-} from '@/lib/openbook';
+import { useCallback } from 'react';
 import { ProposalOpenOrdersTab } from '@/components/Orders/ProposalOpenOrdersTab';
-import { ProposalUnsettledOrdersTab } from '@/components/Orders/ProposalUnsettledOrdersTab';
 import { ProposalUncrankedOrdersTab } from '@/components/Orders/ProposalUncrankedOrdersTab';
+import { ProposalUnsettledOrdersTab } from '@/components/Orders/ProposalUnsettledOrdersTab';
+import { useProposal } from '@/contexts/ProposalContext';
 import { useProposalMarkets } from '@/contexts/ProposalMarketsContext';
 import { useOpenbook } from '@/hooks/useOpenbook';
-import { useCallback } from 'react';
+import { totalMetaInOrder, totalUsdcInOrder } from '@/lib/openbook';
 
 export function ProposalOrdersCard() {
   const { publicKey: owner } = useWallet();

--- a/contexts/BalancesContext.tsx
+++ b/contexts/BalancesContext.tsx
@@ -231,7 +231,5 @@ export function BalancesProvider({ children }: { children: React.ReactNode }) {
     [balances],
   );
 
-  console.log('value.balances', value.balances);
-
   return <balancesContext.Provider value={value}>{children}</balancesContext.Provider>;
 }

--- a/contexts/ProposalContext.tsx
+++ b/contexts/ProposalContext.tsx
@@ -7,10 +7,7 @@ import {
 } from '@solana/spl-token';
 import { notifications } from '@mantine/notifications';
 import { useQueryClient } from '@tanstack/react-query';
-import {
-  Proposal,
-  ProposalAccountWithKey,
-} from '@/lib/types';
+import { Proposal, ProposalAccountWithKey } from '@/lib/types';
 import { useAutocrat } from '@/contexts/AutocratContext';
 import { useConditionalVault } from '@/hooks/useConditionalVault';
 import { useOpenbookTwap } from '@/hooks/useOpenbookTwap';
@@ -57,10 +54,9 @@ export function ProposalProvider({
   fromProposal?: ProposalAccountWithKey;
 }) {
   const client = useQueryClient();
-  const { autocratProgram, dao, daoState, daoTreasury, proposals } =
-    useAutocrat();
+  const { autocratProgram, dao, daoState, daoTreasury, proposals } = useAutocrat();
   const { connection } = useConnection();
-  const { markets, fetchMarketsInfo, fetchOpenOrders } = useProposalMarkets();
+  const { markets, fetchMarketsInfo } = useProposalMarkets();
   const wallet = useWallet();
   const sender = useTransactionSender();
   const {
@@ -116,12 +112,12 @@ export function ProposalProvider({
       const userBasePass = getAssociatedTokenAddressSync(
         baseVault.conditionalOnFinalizeTokenMint,
         wallet.publicKey,
-        true
+        true,
       );
       const userQuotePass = getAssociatedTokenAddressSync(
         quoteVault.conditionalOnFinalizeTokenMint,
         wallet.publicKey,
-        true
+        true,
       );
       const metaTokenAccount = getAssociatedTokenAddressSync(metaMint, wallet.publicKey, true);
 
@@ -270,14 +266,13 @@ export function ProposalProvider({
         if (!passTxs || !failTxs) return;
         const txs = [...passTxs, ...failTxs].filter(Boolean);
         await sender.send(txs as VersionedTransaction[]);
-        fetchOpenOrders(wallet.publicKey);
       } catch (err) {
         console.error(err);
       } finally {
         setIsCranking(false);
       }
     },
-    [markets, proposal, wallet.publicKey, sender, crankMarketTransactions, fetchOpenOrders],
+    [markets, proposal, wallet.publicKey, sender, crankMarketTransactions],
   );
 
   return (

--- a/contexts/ProposalMarketsContext.tsx
+++ b/contexts/ProposalMarketsContext.tsx
@@ -823,7 +823,6 @@ export function ProposalMarketsProvider({
             },
           ];
           // Setup Websocket subscription for the two sides
-          // TODO pass in markets here to consume order book side
           try {
             const subscriptionIds = sides.map((side) =>
               provider.connection.onAccountChange(
@@ -893,7 +892,6 @@ export function ProposalMarketsProvider({
   );
 
   useEffect(() => {
-    // TODO, TEST IT!!
     const handleOrderBooklistening = async () => {
       if (!wsConnected && proposal && markets && openBookProgram) {
         // connect for both pass and fail market order books

--- a/contexts/ProposalMarketsContext.tsx
+++ b/contexts/ProposalMarketsContext.tsx
@@ -796,7 +796,6 @@ export function ProposalMarketsProvider({
     }
   }, [orderBookObject]);
 
-  // need to put this in a useEffect that takes all the parameters and passes them on down baby
   const listenOrderBooks = async (
     proposal: Proposal,
     markets: Markets,

--- a/contexts/ProposalMarketsContext.tsx
+++ b/contexts/ProposalMarketsContext.tsx
@@ -305,19 +305,6 @@ export function ProposalMarketsProvider({
   }, [proposal]);
 
   useEffect(() => {
-    if (proposal && wallet.publicKey && markets) {
-      refreshUserOpenOrders(
-        openBookClient,
-        proposal,
-        markets.passBids,
-        markets.passAsks,
-        markets.failBids,
-        markets.failAsks,
-      );
-    }
-  }, [markets, proposal]);
-
-  useEffect(() => {
     if (!markets && proposal) {
       fetchMarketsInfo();
     }

--- a/contexts/ProposalMarketsContext.tsx
+++ b/contexts/ProposalMarketsContext.tsx
@@ -188,7 +188,7 @@ export function ProposalMarketsProvider({
             failUncrankedOrders,
           ];
         },
-        staleTime: 30_000,
+        staleTime: 5_000,
       });
 
       if (nonOpenOrders.length > 0) {
@@ -564,14 +564,6 @@ export function ProposalMarketsProvider({
 
         const txsSent = await sender.send(placeTxs);
         await fetchMarketsInfo();
-        await refreshUserOpenOrders(
-          openBookClient,
-          proposal,
-          markets.passBids,
-          markets.passAsks,
-          markets.failBids,
-          markets.failAsks,
-        );
         return txsSent;
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
- Order book data populated user open orders table
- Must still manually fetch non-open orders. This is done when accessing either the unsettled or uncranked tabs