### PR TITLE
Fix blockhask -> blockhash typo

### DIFF
--- a/hooks/useAutocratDebug.ts
+++ b/hooks/useAutocratDebug.ts
@@ -34,9 +34,9 @@ export function useAutocratDebug() {
         .instruction(),
     );
 
-    const blockhask = await connection.getLatestBlockhash();
+    const blockhash = await connection.getLatestBlockhash();
     daoTx.feePayer = wallet.publicKey!;
-    daoTx.recentBlockhash = blockhask.blockhash;
+    daoTx.recentBlockhash = blockhash.blockhash;
 
     txs.push(daoTx);
 

--- a/hooks/useInitializeProposal.ts
+++ b/hooks/useInitializeProposal.ts
@@ -144,11 +144,11 @@ export function useInitializeProposal() {
     const passMarketTx = new Transaction().add(...openbookPassMarket.instructions);
     const failMarketTx = new Transaction().add(...openbookFailMarket.instructions);
 
-    const blockhask = await connection.getLatestBlockhash();
+    const blockhash = await connection.getLatestBlockhash();
     passMarketTx.feePayer = wallet.publicKey!;
-    passMarketTx.recentBlockhash = blockhask.blockhash;
+    passMarketTx.recentBlockhash = blockhash.blockhash;
     failMarketTx.feePayer = wallet.publicKey!;
-    failMarketTx.recentBlockhash = blockhask.blockhash;
+    failMarketTx.recentBlockhash = blockhash.blockhash;
 
     passMarketTx.sign(...openbookPassMarket.signers);
     failMarketTx.sign(...openbookFailMarket.signers);
@@ -217,9 +217,9 @@ export function useInitializeProposal() {
       createFailTwapMarketIx,
     );
 
-    const blockhask = await connection.getLatestBlockhash();
+    const blockhash = await connection.getLatestBlockhash();
     twapsTx.feePayer = wallet.publicKey!;
-    twapsTx.recentBlockhash = blockhask.blockhash;
+    twapsTx.recentBlockhash = blockhash.blockhash;
 
     const txs = [twapsTx].filter(Boolean) as Transaction[];
     const signedTxs = await wallet.signAllTransactions(txs);
@@ -281,9 +281,9 @@ export function useInitializeProposal() {
           .instruction(),
       );
 
-      const blockhask = await connection.getLatestBlockhash();
+      const blockhash = await connection.getLatestBlockhash();
       initProposalTx.feePayer = wallet.publicKey!;
-      initProposalTx.recentBlockhash = blockhask.blockhash;
+      initProposalTx.recentBlockhash = blockhash.blockhash;
       initProposalTx.sign(proposalKeypair);
 
       const txs = [initProposalTx];


### PR DESCRIPTION
Please resolve if spelling is intended — I interpreted as a typo and applied a find all + replace