### PR TITLE
Add updated transaction lifecycle (send + confirm) logic

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -4,7 +4,7 @@ import { parsePossibleBoolean } from './utils';
 
 config();
 
-const VERBOSE = parsePossibleBoolean(process.env.VERBOSE) ?? false;
+const VERBOSE_LOGGING = parsePossibleBoolean(process.env.VERBOSE_LOGGING) ?? false;
 
 const LOG_LEVELS = {
   log: { var: 'LOG_ENABLED', method: console.log },
@@ -16,11 +16,8 @@ const LOG_LEVELS = {
 
 const _log = (level: keyof typeof LOG_LEVELS, ...args: any[]): void => {
   if (
-    VERBOSE ||
-    (parsePossibleBoolean(
-      process.env[LOG_LEVELS[level as keyof typeof LOG_LEVELS].var]
-    ) ??
-      false)
+    VERBOSE_LOGGING ||
+    (parsePossibleBoolean(process.env[LOG_LEVELS[level as keyof typeof LOG_LEVELS].var]) ?? false)
   ) {
     LOG_LEVELS[level].method(...args);
   }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,37 @@
+import { config } from 'dotenv';
+
+import { parsePossibleBoolean } from './utils';
+
+config();
+
+const VERBOSE = parsePossibleBoolean(process.env.VERBOSE) ?? false;
+
+const LOG_LEVELS = {
+  log: { var: 'LOG_ENABLED', method: console.log },
+  error: { var: 'ERROR_ENABLED', method: console.error },
+  warn: { var: 'WARN_ENABLED', method: console.warn },
+  debug: { var: 'DEBUG_ENABLED', method: console.debug },
+  info: { var: 'INFO_ENABLED', method: console.info },
+};
+
+const _log = (level: keyof typeof LOG_LEVELS, ...args: any[]): void => {
+  if (
+    VERBOSE ||
+    (parsePossibleBoolean(
+      process.env[LOG_LEVELS[level as keyof typeof LOG_LEVELS].var]
+    ) ??
+      false)
+  ) {
+    LOG_LEVELS[level].method(...args);
+  }
+};
+
+export const log = (...args: any[]): void => _log('error', ...args);
+
+export const error = (...args: any[]): void => _log('error', ...args);
+
+export const warn = (...args: any[]): void => _log('warn', ...args);
+
+export const debug = (...args: any[]): void => _log('debug', ...args);
+
+export const info = (...args: any[]): void => _log('info', ...args);

--- a/lib/transactions/confirm.ts
+++ b/lib/transactions/confirm.ts
@@ -1,0 +1,286 @@
+import {
+  Commitment,
+  Connection,
+  TransactionConfirmationStatus,
+  TransactionSignature,
+} from '@solana/web3.js';
+
+import { debug } from '../logger';
+import { DEFAULT_COMMITMENT, DEFAULT_POLLING_TIMEOUT } from './constants';
+import { TransactionLifecycleEventCallback } from './events';
+import { applyTransactionExpiration } from './timeouts/expiration';
+import { applyStaticTimeout } from './timeouts/static';
+import { NoTimeoutConfig, StaticTimeoutConfig, TransactionExpirationTimeoutConfig } from './types';
+import { abortableSleep, tryInvokeAbort } from './utils';
+
+const TRANSACTION_CONFIRMATION_VALUES = ['processed', 'confirmed', 'finalized'] as const;
+
+const cleanupSubscription = async (connection: Connection, subscriptionId?: number) => {
+  if (subscriptionId) {
+    connection.removeSignatureListener(subscriptionId).catch((err) => {
+      debug(
+        `[Web Socket] error in invoking removeSignatureListener for subscription ${subscriptionId}`,
+        err,
+      );
+    });
+  }
+};
+
+// enum to help define ordering of transaction confirmation statuses
+enum TransactionConfirmationStatusEnum {
+  processed = 1,
+  confirmed,
+  finalized,
+}
+
+const areConfirmationLevelsSatisfied = (
+  requiredStatuses: TransactionConfirmationStatus[],
+  currentStatus?: TransactionConfirmationStatus,
+): boolean => {
+  if (!currentStatus) return false;
+  const currentStatusValue = TransactionConfirmationStatusEnum[currentStatus];
+  const requiredStatusOrders = requiredStatuses.map((s) => TransactionConfirmationStatusEnum[s]);
+
+  return currentStatusValue >= Math.max(...requiredStatusOrders);
+};
+
+/**
+ * Monitors and confirms a transaction signature's status based on specified configurations. The function leverages both
+ * WebSocket and REST polling strategies to verify the transaction status against a set of required confirmation levels.
+ * Waits for the confirmation of a transaction signature. It handles different configurations for timeouts and allows for
+ * the process to be aborted externally. Transaction events are emitted throughout the process for each phase: pending,
+ * active, or completed. The function has 3 steps to it:
+ *
+ * 1. Start an async timeout process in case confirmation takes an arbitrarily long time. We
+ *    want to be able to pull the escape hatch and stop all related processes if exceed the
+ *    specified timeout configuration.
+ * 2. Setup a websocket connection to listen for a events for a signature given a specific
+ *    commitment level.
+ * 3. If the caller requested additional commitment levels beyond what was specified in the
+ *    websocket subscription, we will poll for signature status until we satisfy the additional
+ *    commitment levels.
+ *
+ * As an example, consider the case where a user wants to timeout confirmation after 30 seconds
+ * and wants to use the subscription to wait for an initial 'confirmed' commitment status
+ * but wants to keep polling until it reaches the 'finalized' status. We will first start the
+ * 30 second timer and then setup the subscription to listen for the transaction signature and
+ * provide the 'confirmed' commitment level. Assuming that we get a response that the signature
+ * is successful, we will then start polling for signature status because confirmed < finalized
+ * w.r.t. commitment levels. If we can get a finalized status within 30s from starting the function,
+ * we will return successfully. If not, we will return a rejected promise, indicating there was a timeout.
+ *
+ * @param {Object} params - The parameters needed for transaction signature confirmation.
+ * @param {Connection} params.connection - The blockchain connection used for sending requests and subscribing to events.
+ * @param {string} params.transactionId - The transaction signature to be confirmed.
+ * @param {StaticTimeoutConfig | TransactionExpirationTimeoutConfig | NoTimeoutConfig} [params.config] - The configuration
+ *        defining the confirmation process behavior, including timeouts and required confirmation levels.
+ * @param {TransactionLifecycleEventCallback} [params.onTransactionEvent] - Callback function to handle transaction lifecycle events.
+ * @param {AbortController} [params.controller] - An optional AbortController to manage cancellation of the confirmation process.
+ * @param {Commitment} [params.transactionCommitment] - The commitment level at which the transaction needs to be confirmed.
+ *
+ * @returns {Promise<Object>} - A promise that resolves with the transaction status or rejects with an error if the transaction fails
+ *          to meet the confirmation criteria or if an error occurs during the confirmation process.
+ *
+ * @throws {Error} - Throws an error if the WebSocket or REST polling encounters an exception that is not handled by the configured
+ *                   error management strategy.
+ */
+export const awaitTransactionSignatureConfirmation = async ({
+  connection,
+  transactionId,
+  config,
+  onTransactionEvent,
+  controller: _controller,
+  transactionCommitment,
+}: {
+  connection: Connection;
+  transactionId: TransactionSignature;
+  config?: StaticTimeoutConfig | TransactionExpirationTimeoutConfig | NoTimeoutConfig;
+  onTransactionEvent?: TransactionLifecycleEventCallback;
+  controller?: AbortController;
+  transactionCommitment?: Commitment;
+}) => {
+  const controller = _controller ?? new AbortController();
+
+  const subscriptionConfirmationCommitment =
+    config?.initialConfirmationCommitment ?? connection.commitment ?? DEFAULT_COMMITMENT;
+  const requiredConfirmationLevels = config?.requiredConfirmationLevels ?? ['confirmed'];
+
+  onTransactionEvent?.({
+    type: 'confirm',
+    phase: 'pending',
+    transactionId,
+  });
+
+  /* eslint-disable no-async-promise-executor */
+  const signatureConfirmationResult = await new Promise(async (resolve, reject) => {
+    // [Step 1] kick off timeout processes if specified
+    if (config?.type === 'static') {
+      applyStaticTimeout(config, controller, reject);
+    } else if (config?.type === 'expiration') {
+      applyTransactionExpiration({
+        connection,
+        config,
+        controller,
+        reject,
+        transactionCommitment,
+      });
+    }
+
+    // [Step 2] setup websocket connection to verify signature with intitial commitment
+    await new Promise(async (innerResolve) => {
+      let subscriptionId: number | undefined;
+      try {
+        debug('[WebSocket] Setting up onSignature subscription...');
+        subscriptionId = connection.onSignature(
+          transactionId,
+          async (result) => {
+            debug('[WebSocket] result confirmed: ', transactionId, result);
+
+            cleanupSubscription(connection, subscriptionId);
+            if (result.err) {
+              onTransactionEvent?.({
+                type: 'confirm',
+                phase: 'completed',
+                transactionId,
+                err: result.err,
+                status: subscriptionConfirmationCommitment as TransactionConfirmationStatus,
+              });
+
+              tryInvokeAbort(controller);
+              /* eslint-disable prefer-promise-reject-errors */
+              reject({
+                err: result.err,
+              });
+            } else {
+              const isValidConfirmationValue = TRANSACTION_CONFIRMATION_VALUES.includes(
+                subscriptionConfirmationCommitment as Extract<
+                  Commitment,
+                  TransactionConfirmationStatus
+                >,
+              );
+
+              // resolve promise if valid transaction confirmation value OR all target commitments are satisfied.
+              // else, continue polling for transaction status below.
+              if (
+                !isValidConfirmationValue ||
+                (isValidConfirmationValue &&
+                  areConfirmationLevelsSatisfied(
+                    requiredConfirmationLevels,
+                    subscriptionConfirmationCommitment as TransactionConfirmationStatus,
+                  ))
+              ) {
+                onTransactionEvent?.({
+                  type: 'confirm',
+                  phase: 'completed',
+                  transactionId,
+                  status: subscriptionConfirmationCommitment as TransactionConfirmationStatus,
+                });
+
+                tryInvokeAbort(controller);
+                resolve(result);
+              } else {
+                onTransactionEvent?.({
+                  type: 'confirm',
+                  phase: 'pending',
+                  transactionId,
+                  status: subscriptionConfirmationCommitment as TransactionConfirmationStatus,
+                });
+
+                innerResolve(result);
+              }
+            }
+          },
+          subscriptionConfirmationCommitment,
+        );
+
+        debug('[WebSocket] Setup connection for transaction ', transactionId);
+        controller.signal.addEventListener('abort', () => {
+          cleanupSubscription(connection, subscriptionId);
+        });
+      } catch (err: any) {
+        // note: at the moment, no event callback invoked here
+
+        cleanupSubscription(connection, subscriptionId);
+        tryInvokeAbort(controller);
+        debug('[WebSocket] error: ', transactionId, err);
+      }
+    });
+
+    // [Step 3] start polling signature status if caller requested additional commitment levels
+    // beyond the commitment specified in the above websocket subscription
+    const pollingTimeout = config?.pollingConfirmationTimeoutMs ?? DEFAULT_POLLING_TIMEOUT;
+    while (!controller.signal.aborted) {
+      try {
+        /* eslint-disable no-await-in-loop */
+        const signatureStatuses = await connection.getSignatureStatuses([transactionId]);
+        debug('[REST] Signature status result: ', signatureStatuses);
+
+        const result = signatureStatuses && signatureStatuses.value[0];
+        if (!controller.signal.aborted) {
+          if (!result) {
+            debug('[REST] result is null: ', transactionId, result);
+          } else if (result.err) {
+            debug('[REST] result has error: ', transactionId, result);
+
+            onTransactionEvent?.({
+              type: 'confirm',
+              phase: 'completed',
+              transactionId,
+              err: result.err,
+              status: result.confirmationStatus,
+            });
+
+            tryInvokeAbort(controller);
+
+            /* eslint-disable prefer-promise-reject-errors */
+            reject({
+              err: result.err,
+            });
+          } else if (!(result.confirmations || result.confirmationStatus)) {
+            debug(
+              '[REST] result "confirmations" or "confirmationStatus" is null: ',
+              transactionId,
+              requiredConfirmationLevels,
+              result,
+            );
+          } else if (
+            !areConfirmationLevelsSatisfied(requiredConfirmationLevels, result.confirmationStatus)
+          ) {
+            debug('[REST] result confirmed with commitment: ', transactionId, result);
+
+            onTransactionEvent?.({
+              type: 'confirm',
+              phase: 'active',
+              transactionId,
+              status: result.confirmationStatus,
+            });
+          } else {
+            debug('[REST] result confirmed: ', transactionId, result);
+
+            onTransactionEvent?.({
+              type: 'confirm',
+              phase: 'completed',
+              transactionId,
+              status: result.confirmationStatus,
+            });
+
+            tryInvokeAbort(controller);
+            resolve(result);
+          }
+        }
+      } catch (e) {
+        // note: at the moment, no event callback invoked here
+        if (!controller.signal.aborted) {
+          debug('[REST] connection error: ', transactionId, e);
+        }
+
+        tryInvokeAbort(controller);
+      }
+
+      /* eslint-disable no-await-in-loop */
+      await abortableSleep(pollingTimeout, controller);
+    }
+  });
+
+  return signatureConfirmationResult;
+};

--- a/lib/transactions/constants.ts
+++ b/lib/transactions/constants.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_COMMITMENT = 'confirmed';
+
+export const DEFAULT_POLLING_TIMEOUT = 2_000;

--- a/lib/transactions/errors/index.ts
+++ b/lib/transactions/errors/index.ts
@@ -1,0 +1,3 @@
+export * from './instruction';
+export * from './signature';
+export * from './timeout';

--- a/lib/transactions/errors/instruction.ts
+++ b/lib/transactions/errors/instruction.ts
@@ -1,0 +1,63 @@
+import {
+  AccountMeta,
+  Transaction,
+  TransactionError,
+  TransactionInstruction,
+  VersionedMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+export class InstructionError extends Error {
+  transactionId?: string;
+  message: string;
+  error: TransactionError;
+  instruction: TransactionInstruction;
+
+  constructor({
+    transactionId,
+    transaction,
+    error,
+    message,
+  }: {
+    transactionId?: string;
+    transaction: Transaction | VersionedTransaction;
+    error: TransactionError;
+    message?: string;
+  }) {
+    super();
+    this.transactionId = transactionId;
+    this.error = error;
+
+    const [ixKey, errorName] = (error as any).InstructionError;
+    this.instruction =
+      transaction instanceof Transaction
+        ? transaction.instructions[ixKey]
+        : this.toTransactionInstruction(transaction.message, ixKey);
+
+    const displayableErrorName =
+      typeof errorName === 'string' ? errorName : JSON.stringify(errorName);
+    this.message =
+      message ??
+      `Transaction failed with error ${displayableErrorName} at instruction at index = ${ixKey}`;
+  }
+
+  private toTransactionInstruction = (
+    message: VersionedMessage,
+    idx: number,
+  ): TransactionInstruction => {
+    const instruction = message.compiledInstructions[idx];
+    const accountKeys = message.getAccountKeys();
+    return new TransactionInstruction({
+      keys: instruction.accountKeyIndexes.map(
+        (i) =>
+          ({
+            pubkey: accountKeys.staticAccountKeys[i],
+            isSigner: message.isAccountSigner(i),
+            isWritable: message.isAccountWritable(i),
+          } as AccountMeta),
+      ),
+      programId: accountKeys.staticAccountKeys[instruction.programIdIndex],
+      data: Buffer.from(instruction.data),
+    });
+  };
+}

--- a/lib/transactions/errors/signature.ts
+++ b/lib/transactions/errors/signature.ts
@@ -1,0 +1,28 @@
+import { Transaction, VersionedTransaction } from '@solana/web3.js';
+
+/**
+ * Handle errors thrown specifically on the Transaction::serialize method.
+ * Errors are either Invalid, Missing, or General verification failure
+ *
+ * source: https://github.com/solana-labs/solana-web3.js/blob/7265594ce8ac9480dea2b0f5fe84b24fdacf115b/packages/library-legacy/src/transaction/legacy.ts#L797-L833
+ */
+export class SignatureError extends Error {
+  message: string;
+  rawTransaction: Buffer | Uint8Array;
+
+  constructor({
+    transaction,
+    message,
+  }: {
+    transaction: Transaction | VersionedTransaction;
+    message: string;
+  }) {
+    super();
+
+    this.message = message;
+    this.rawTransaction = transaction.serialize({
+      requireAllSignatures: false,
+      verifySignatures: false,
+    });
+  }
+}

--- a/lib/transactions/errors/timeout.ts
+++ b/lib/transactions/errors/timeout.ts
@@ -1,0 +1,49 @@
+import {
+  StaticTimeoutConfig,
+  TransactionExpirationTimeoutConfig,
+} from '../types';
+
+namespace ConfirmationTimeoutError {
+  export type ErrorTimeoutConfig =
+    | Pick<StaticTimeoutConfig, 'type' | 'timeoutMs'>
+    | Pick<
+        TransactionExpirationTimeoutConfig,
+        'type' | 'transactionCommitment' | 'blockhashValidityPollingTimeoutMs'
+      >;
+}
+
+export class ConfirmationTimeoutError extends Error {
+  transactionId: string;
+  message: string;
+  config: ConfirmationTimeoutError.ErrorTimeoutConfig;
+
+  constructor({
+    transactionId,
+    message,
+    config,
+  }: {
+    transactionId: string;
+    message: string;
+    config: ConfirmationTimeoutError.ErrorTimeoutConfig;
+  }) {
+    super();
+    this.message = message;
+    this.transactionId = transactionId;
+    this.config = config;
+  }
+
+  static formatConfig = (
+    config: StaticTimeoutConfig | TransactionExpirationTimeoutConfig
+  ) =>
+    config.type === 'static'
+      ? {
+          type: config.type,
+          timeoutMs: config.timeoutMs,
+        }
+      : {
+          type: config.type,
+          transactionCommitment: config.transactionCommitment,
+          blockhashValidityPollingTimeoutMs:
+            config.blockhashValidityPollingTimeoutMs,
+        };
+}

--- a/lib/transactions/errors/transaction.ts
+++ b/lib/transactions/errors/transaction.ts
@@ -1,0 +1,16 @@
+export class TransactionError extends Error {
+  message: string;
+  transactionId?: string;
+
+  constructor({
+    transactionId,
+    message,
+  }: {
+    transactionId?: string;
+    message: string;
+  }) {
+    super();
+    this.message = message;
+    this.transactionId = transactionId;
+  }
+}

--- a/lib/transactions/events.ts
+++ b/lib/transactions/events.ts
@@ -1,0 +1,46 @@
+import {
+  SimulatedTransactionResponse,
+  TransactionConfirmationStatus,
+  TransactionError,
+  TransactionSignature,
+} from '@solana/web3.js';
+
+export type EventPhase = 'pending' | 'active' | 'completed';
+
+export interface TransactionSimulateEvent {
+  type: 'simulate';
+  status?: 'success' | 'failed';
+  err?: any;
+  phase: EventPhase;
+  transactionId?: TransactionSignature;
+  result?: SimulatedTransactionResponse;
+}
+
+export interface TransactionSentEvent {
+  type: 'send';
+  phase: EventPhase;
+  transactionId?: TransactionSignature;
+}
+
+export interface TransactionConfirmedEvent {
+  type: 'confirm';
+  phase: EventPhase;
+  status?: TransactionConfirmationStatus;
+  err?: TransactionError;
+  transactionId: TransactionSignature;
+}
+
+export interface TransactionTimeoutEvent {
+  type: 'timeout';
+  phase: EventPhase;
+  transactionId: TransactionSignature;
+  durationMs: number;
+}
+
+export type TransactionLifecycleEventCallback = (
+  event:
+    | TransactionSentEvent
+    | TransactionConfirmedEvent
+    | TransactionTimeoutEvent
+    | TransactionSimulateEvent
+) => void;

--- a/lib/transactions/send.ts
+++ b/lib/transactions/send.ts
@@ -1,0 +1,125 @@
+import {
+  Connection,
+  SendTransactionError,
+  Transaction,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+import { error, log } from '../logger';
+import { SignatureError } from './errors';
+import { TransactionLifecycleEventCallback } from './events';
+import { SendTransactionConfig } from './types';
+import { abortableSleep, getTransactionSignatureOrThrow } from './utils';
+
+const MAX_SEND_TX_RETRIES = 10;
+
+// source: https://github.com/solana-labs/solana-web3.js/blob/master/packages/errors/src/messages.ts
+const TRANSACTION_ALREADY_PROCESSED_MESSAGE = 'This transaction has already been processed';
+
+/**
+ * Asynchronously sends a signed transaction to the Solana network and invoke a callback function for various lifecycle events.
+ * This function supports both one-time and continuous transaction submissions, with configurable options for sending transactions
+ * such as skipping preflight checks and setting maximum retries.
+ *
+ * @param {Object} params - The parameters for sending the transaction.
+ * @param {Transaction | VersionedTransaction} params.signedTransaction - The signed transaction to be sent.
+ * @param {Connection} params.connection - The blockchain connection to use for sending the transaction.
+ * @param {SendTransactionConfig} [params.config] - Optional configuration for transaction sending options,
+ *        including whether to skip preflight checks, the number of maximum retries, the timeout for polling in continuous mode,
+ *        and an AbortController for handling cancellations in continuous mode.
+ * @param {TransactionLifecycleEventCallback} [params.onTransactionEvent] - Optional callback to handle transaction lifecycle events,
+ *        which are invoked with an object containing the type of event, the transaction phase, and the transaction ID.
+ *
+ * @returns {Promise<string>} - A promise that resolves to the transaction ID of the submitted transaction.
+ *
+ * @throws {SignatureError} - Throws an error if there is a signature error in the transaction serialization process.
+ * @throws {Error} - Throws a general error if the transaction fails to send, or if required configurations for continuous sending are missing.
+ */
+export const sendSignedTransaction = async ({
+  signedTransaction,
+  connection,
+  config = {
+    sendOptions: {
+      skipPreflight: true,
+      maxRetries: MAX_SEND_TX_RETRIES,
+    },
+  },
+  onTransactionEvent,
+}: {
+  signedTransaction: Transaction | VersionedTransaction;
+  connection: Connection;
+  config?: SendTransactionConfig;
+  onTransactionEvent?: TransactionLifecycleEventCallback;
+}): Promise<string> => {
+  const transactionProcessedController = new AbortController();
+  let rawTransaction: Buffer | Uint8Array;
+
+  try {
+    /**
+     * throws on signature errors unless explicitly told not to via config
+     *
+     * source: https://github.com/solana-labs/solana-web3.js/blob/7265594ce8ac9480dea2b0f5fe84b24fdacf115b/packages/library-legacy/src/transaction/legacy.ts#L797-L833
+     */
+    rawTransaction = signedTransaction.serialize();
+  } catch (err: any) {
+    error('Serialize transaction error: ', err.message);
+    throw new SignatureError({
+      transaction: signedTransaction,
+      message: err.message,
+    });
+  }
+
+  const transactionId = getTransactionSignatureOrThrow(signedTransaction);
+  (async () => {
+    const pollingSendTransactionTimeoutMs = config.pollingSendTransactionTimeoutMs ?? 1_000;
+    const continuouslySendTransactions = config.continuouslySendTransactions ?? false;
+
+    if (continuouslySendTransactions && !config.controller) {
+      throw new Error(
+        'AbortController is required to continuously send a transaction to the cluster',
+      );
+    }
+
+    while (!transactionProcessedController.signal.aborted && !config.controller?.signal.aborted) {
+      onTransactionEvent?.({
+        type: 'send',
+        phase: 'pending',
+        transactionId,
+      });
+
+      /**
+       * todo: handle the possible `SendTransactionError` errors, which right now we just catch and
+       * throw a generic error related to sending a transaction
+       *
+       * source: https://github.com/solana-labs/solana-web3.js/blob/2d48c0954a3823b937a9b4e572a8d63cd7e4631c/packages/library-legacy/src/connection.ts#L5918-L5927
+       */
+      connection
+        .sendRawTransaction(rawTransaction, config.sendOptions)
+        .catch((err: SendTransactionError) => {
+          if (err.message.includes(TRANSACTION_ALREADY_PROCESSED_MESSAGE)) {
+            transactionProcessedController.abort();
+            return;
+          }
+
+          error('SendTransactionError: ', err);
+          throw new Error('Failed to send transaction');
+        });
+
+      onTransactionEvent?.({
+        type: 'send',
+        phase: 'completed',
+        transactionId,
+      });
+
+      if (!continuouslySendTransactions) {
+        log('[Continuous send = false] first transaction sent, bailing...');
+        break;
+      }
+
+      /* eslint-disable no-await-in-loop */
+      await abortableSleep(pollingSendTransactionTimeoutMs, config.controller);
+    }
+  })();
+
+  return transactionId;
+};

--- a/lib/transactions/sendAndConfirm.ts
+++ b/lib/transactions/sendAndConfirm.ts
@@ -1,0 +1,136 @@
+import { Connection, Transaction, VersionedTransaction } from '@solana/web3.js';
+
+import { log } from '../logger';
+import { awaitTransactionSignatureConfirmation } from './confirm';
+import { ConfirmationTimeoutError, InstructionError } from './errors';
+import { TransactionError } from './errors/transaction';
+import { TransactionLifecycleEventCallback } from './events';
+import { sendSignedTransaction } from './send';
+import {
+  NoTimeoutConfig,
+  SendTransactionConfig,
+  StaticTimeoutConfig,
+  TransactionExpirationTimeoutConfig,
+} from './types';
+import { getUnixTs, tryInvokeAbort } from './utils';
+
+const DEFAULT_CONFIRMATION_TIMEOUT = 30_000;
+
+/**
+ * Sends a signed transaction and then awaits its confirmation according to the specified configurations.
+ *
+ * @param {Object} params - The parameters for sending and confirming the transaction.
+ * @param {Transaction | VersionedTransaction} params.signedTransaction - The signed transaction to be sent.
+ * @param {Connection} params.connection - The blockchain connection to use for sending the transaction and monitoring its confirmation.
+ * @param {SendTransactionConfig & (StaticTimeoutConfig | TransactionExpirationTimeoutConfig | NoTimeoutConfig)} [params.config] - Configuration options for sending and confirming the transaction, including timeout settings and send options.
+ * @param {TransactionLifecycleEventCallback} [params.onTransactionEvent] - Optional callback to handle transaction lifecycle events.
+ *
+ * @returns {Promise<string>} - A promise that resolves with the transaction ID if the transaction is confirmed successfully, or rejects with an error if the transaction fails or timeouts.
+ *
+ * @throws {ConfirmationTimeoutError} - Throws this error if the confirmation process times out.
+ * @throws {InstructionError} - Throws this error if there is an issue with the transaction's instructions.
+ * @throws {TransactionError} - Throws this error for general transaction failures.
+ */
+
+export const sendAndConfirmTransaction = async ({
+  signedTransaction,
+  connection,
+  config = {
+    type: 'static',
+    timeoutMs: DEFAULT_CONFIRMATION_TIMEOUT,
+  },
+  onTransactionEvent,
+}: {
+  signedTransaction: Transaction | VersionedTransaction;
+  connection: Connection;
+  config?: SendTransactionConfig &
+    (
+      | StaticTimeoutConfig
+      | TransactionExpirationTimeoutConfig
+      | NoTimeoutConfig
+    );
+  onTransactionEvent?: TransactionLifecycleEventCallback;
+}): Promise<string> => {
+  const startTime = getUnixTs();
+  const controller = new AbortController();
+
+  const {
+    continuouslySendTransactions,
+    pollingSendTransactionTimeoutMs,
+    sendOptions,
+    ...confirmationConfig
+  } = config;
+
+  const transactionId = await sendSignedTransaction({
+    signedTransaction,
+    connection,
+    config: {
+      controller,
+      continuouslySendTransactions,
+      pollingSendTransactionTimeoutMs,
+      sendOptions,
+    },
+    onTransactionEvent,
+  });
+
+  if (confirmationConfig.type === 'none') {
+    controller.abort();
+    log(
+      'Caller requested no confirmation, skipping all confirmation and returning after initial transaction sent to cluster'
+    );
+
+    return transactionId;
+  }
+
+  try {
+    await awaitTransactionSignatureConfirmation({
+      connection,
+      transactionId,
+      config: confirmationConfig,
+      onTransactionEvent,
+      controller,
+      transactionCommitment:
+        confirmationConfig?.type === 'expiration'
+          ? confirmationConfig?.transactionCommitment
+          : undefined,
+    });
+
+    log(
+      'Finished transaction status confirmation: ',
+      transactionId,
+      getUnixTs() - startTime
+    );
+  } catch (error: any) {
+    if (error.timeout) {
+      throw new ConfirmationTimeoutError({
+        transactionId,
+        message: 'Timed out awaiting confirmation on transaction',
+        config: ConfirmationTimeoutError.formatConfig(confirmationConfig),
+      });
+    } else if (error.err) {
+      throw new InstructionError({
+        transactionId,
+        error: error.err,
+        transaction: signedTransaction,
+      });
+    }
+
+    // note: if we want to try and get more information about a transaction failure, we could make a simulate transaction request here
+
+    // question: is there any additional processing we can do to give back more information to the caller?
+    throw new TransactionError({
+      message: 'Transaction failed',
+      transactionId,
+    });
+  } finally {
+    tryInvokeAbort(controller);
+  }
+
+  log(
+    'Transaction confirmation latency: ',
+    transactionId,
+    getUnixTs() - startTime
+  );
+
+  return transactionId;
+};

--- a/lib/transactions/simulate.ts
+++ b/lib/transactions/simulate.ts
@@ -1,0 +1,151 @@
+import {
+  Connection,
+  SimulateTransactionConfig,
+  SimulatedTransactionResponse,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
+
+import { debug, error, log } from '../logger';
+import { InstructionError } from './errors';
+import { TransactionError } from './errors/transaction';
+import { TransactionSimulateEvent } from './events';
+import { getTransactionSignature } from './utils';
+
+const toVersionedTransaction = async ({
+  connection,
+  transaction,
+}: {
+  connection: Connection;
+  transaction: Transaction;
+}) => {
+  if (!transaction.feePayer) {
+    throw new Error('Cannot convert a transaction that is missing fee payer');
+  }
+
+  const { blockhash: recentBlockhash } = await connection.getLatestBlockhash({
+    commitment: 'confirmed',
+  });
+
+  return new VersionedTransaction(
+    new TransactionMessage({
+      payerKey: transaction.feePayer!,
+      recentBlockhash,
+      instructions: transaction.instructions,
+    }).compileToV0Message(),
+  );
+};
+
+/**
+ * Simulates a transaction on the Solana blockchain.
+ *
+ * @param transaction - The transaction to simulate.
+ * @param connection - The Solana connection object.
+ * @param config - The configuration options for the simulation (optional).
+ * @param onTransactionEvent - The callback function to handle transaction events (optional).
+ *
+ * @returns A promise that resolves to the simulated transaction response.
+ * @throws {TransactionError} If the simulation result is null.
+ * @throws {InstructionError} If the simulation result contains an error.
+ */
+export const simulateTransaction = async ({
+  transaction,
+  connection,
+  config = {
+    commitment: 'confirmed',
+  },
+  onTransactionEvent,
+}: {
+  transaction: Transaction | VersionedTransaction;
+  connection: Connection;
+  config?: SimulateTransactionConfig;
+  onTransactionEvent?: (event: TransactionSimulateEvent) => void;
+}): Promise<SimulatedTransactionResponse> => {
+  const transactionId = getTransactionSignature(transaction);
+
+  debug('Transaction failed, trying to simulate transaction');
+  let simulationResult: SimulatedTransactionResponse | null = null;
+  try {
+    const transactionToSimulate =
+      transaction instanceof VersionedTransaction
+        ? transaction
+        : await toVersionedTransaction({
+            connection,
+            transaction,
+          });
+
+    onTransactionEvent?.({
+      type: 'simulate',
+      phase: 'pending',
+      transactionId,
+    });
+
+    simulationResult = (await connection.simulateTransaction(transactionToSimulate, config)).value;
+
+    log(`Transaction ${transactionId} simulation result: `, simulationResult);
+    onTransactionEvent?.({
+      type: 'simulate',
+      phase: 'completed',
+      status: 'success',
+      transactionId,
+      result: simulationResult,
+    });
+  } catch (err) {
+    // note: at the moment, no event callback invoked here
+    error(`Simulate transaction ${transactionId} threw an error: `, err);
+
+    throw new TransactionError({
+      message: 'Unable to simulate failed transaction',
+      transactionId,
+    });
+  }
+
+  // todo: what are the cases in which this result is null?
+  if (!simulationResult) {
+    error(`Simulate transaction ${transactionId} result was null`);
+
+    onTransactionEvent?.({
+      type: 'simulate',
+      phase: 'completed',
+      status: 'failed',
+      transactionId,
+    });
+
+    throw new TransactionError({
+      message: 'Unable to simulate failed transaction',
+      transactionId,
+    });
+  } else {
+    debug(`Simulate transaction ${transactionId} result: `, simulationResult);
+
+    onTransactionEvent?.({
+      type: 'simulate',
+      phase: 'completed',
+      status: 'success',
+      transactionId,
+      result: simulationResult,
+    });
+
+    if (simulationResult.err) {
+      error(
+        'Transaction error from simulation: ',
+        JSON.stringify(simulationResult.err, undefined, 2),
+      );
+
+      // note: mango parses logs if available to surface a transaction message
+      // source: https://github.com/blockworks-foundation/mango-client-v3/blob/fb92f9cf8caaf72966e4f4135c9d6ebd14756df4/src/client.ts#L521
+      if (!simulationResult.logs) {
+        debug(`Simulate transaction ${transactionId} logs: `, simulationResult.logs);
+      }
+
+      throw new InstructionError({
+        transactionId,
+        error: simulationResult.err,
+        transaction,
+      });
+    }
+  }
+
+  return simulationResult;
+};

--- a/lib/transactions/timeouts/expiration.ts
+++ b/lib/transactions/timeouts/expiration.ts
@@ -1,0 +1,63 @@
+import { Commitment, Connection } from '@solana/web3.js';
+
+import { DEFAULT_COMMITMENT, DEFAULT_POLLING_TIMEOUT } from '../constants';
+import { TransactionExpirationTimeoutConfig } from '../types';
+import { abortableSleep } from '../utils';
+import { log } from '../../logger';
+
+/**
+ * Monitors the validity of a blockhash associated with a transaction, repeatedly polling until the blockhash expires
+ * or the process is aborted. If the blockhash is determined to be invalid and the abort signal has not been triggered,
+ * the process is aborted and the associated promise is rejected. This function is used to manage transaction expiration
+ * in environments where transaction validity is linked to blockhash validity for a set period.
+ *
+ * See the following link for information on transaction expiry: https://solana.com/docs/core/transactions/confirmation#why-do-transactions-expire
+ *
+ * @param {Object} params - The parameters for checking blockhash expiration.
+ * @param {Connection} params.connection - The connection to use for checking blockhash validity.
+ * @param {TransactionExpirationTimeoutConfig} params.config - Configuration for transaction expiration,
+ *        including the blockhash to check and the polling timeout in milliseconds.
+ * @param {AbortController} params.controller - The AbortController used to manage abortion of the blockhash checking process.
+ * @param {(reason?: any) => void} params.reject - The reject function of the Promise to be called if the blockhash is found to be invalid.
+ * @param {Commitment} [params.transactionCommitment] - The commitment level to use when checking blockhash validity, which influences
+ *        how the network confirms the status of a blockhash.
+ */
+
+export const applyTransactionExpiration = async ({
+  connection,
+  config,
+  controller,
+  reject,
+  transactionCommitment,
+}: {
+  connection: Connection;
+  config: TransactionExpirationTimeoutConfig;
+  controller: AbortController;
+  reject: (reason?: any) => void;
+  transactionCommitment?: Commitment;
+}) => {
+  const pollingTimeout = config.blockhashValidityPollingTimeoutMs ?? DEFAULT_POLLING_TIMEOUT;
+  const commitment = transactionCommitment ?? connection.commitment ?? DEFAULT_COMMITMENT;
+
+  while (!controller.signal.aborted) {
+    /* eslint-disable no-await-in-loop */
+    const isBlockhashValid = await connection.isBlockhashValid(config.transactionBlockhash, {
+      commitment,
+    });
+
+    log(
+      `blockhash: ${config.transactionBlockhash}, commitment: ${commitment} is valid? `,
+      isBlockhashValid,
+    );
+
+    if (!isBlockhashValid.value) {
+      if (controller.signal.aborted) return;
+      controller.abort();
+
+      reject({ timeout: true });
+    }
+
+    /* eslint-disable no-await-in-loop */
+    await abortableSleep(pollingTimeout, controller);
+  }
+};

--- a/lib/transactions/timeouts/static.ts
+++ b/lib/transactions/timeouts/static.ts
@@ -1,0 +1,29 @@
+import { log } from '../../logger';
+import { StaticTimeoutConfig } from '../types';
+
+/**
+ * Applies a static timeout to an asynchronous operation, aborting the process if the specified time limit is exceeded.
+ * If the timeout is reached and the controller's abort signal has not been activated, it aborts the operation and
+ * rejects the associated promise. Additionally, it handles cleanup if the abort signal is activated before the timeout.
+ *
+ * @param {StaticTimeoutConfig} config - Configuration object that includes the timeout duration in milliseconds.
+ * @param {AbortController} controller - The AbortController associated with the asynchronous operation to be controlled.
+ * @param {(reason?: any) => void} reject - The reject function of the Promise that should be called if the operation times
+ */
+export const applyStaticTimeout = (
+  config: StaticTimeoutConfig,
+  controller: AbortController,
+  reject: (reason?: any) => void
+) => {
+  const timeoutId = setTimeout(() => {
+    if (controller.signal.aborted) return;
+    controller.abort();
+
+    reject({ timeout: true });
+  }, config.timeoutMs);
+
+  controller.signal.addEventListener('abort', () => {
+    log(`Controller signal aborted, cancelling static timeout: ${timeoutId}`);
+    clearTimeout(timeoutId);
+  });
+};

--- a/lib/transactions/types.ts
+++ b/lib/transactions/types.ts
@@ -1,0 +1,76 @@
+import {
+  Blockhash,
+  Commitment,
+  SendOptions,
+  TransactionConfirmationStatus,
+} from '@solana/web3.js';
+
+export type SendTransactionConfig = {
+  /**
+   * Controller used to decide when to stop sending transactions iff `continuouslySendTransactions` is defined
+   * and has a boolean value of true
+   */
+  controller?: AbortController;
+  /**
+   * Whether or not the transaction should continuously be sent to the cluster
+   * before returning.
+   */
+  continuouslySendTransactions?: boolean;
+  /**
+   * If continuously sending transactions to the cluster status is used, what is the
+   * amount of time between calls, in milliseconds. Ignored if 'continuouslySendTransactions'
+   * is false.
+   */
+  pollingSendTransactionTimeoutMs?: number;
+  /**
+   * Options passed to the `sendRawTransaction` function from the Connection class in @solana/webe.js
+   */
+  sendOptions?: SendOptions;
+};
+
+export type BaseConfig = {
+  /**
+   * Commitment level used when first setting up a websocket connection
+   * to listen for the status of a transaction.
+   */
+  initialConfirmationCommitment?: Commitment;
+  /**
+   * The confirmation status values that should be verified before returning.
+   */
+  requiredConfirmationLevels?: TransactionConfirmationStatus[];
+  /**
+   * If polling for transaction status is used, what is the amount of time between
+   * calls, in milliseconds.
+   */
+  pollingConfirmationTimeoutMs?: number;
+  /**
+   * Commitment level used when creating the transaction. If not defined,
+   * the fallback values will be:
+   *
+   * 1. the Connection instance's commitment level,
+   * 2. the defined `DEFAULT_COMMITMENT` constant
+   */
+  transactionCommitment?: Commitment;
+};
+
+export type StaticTimeoutConfig = BaseConfig & {
+  type: 'static';
+  /**
+   * Duration to wait when confirming a transaction before timing out, in milliseconds.
+   */
+  timeoutMs: number;
+};
+
+export type TransactionExpirationTimeoutConfig = BaseConfig & {
+  type: 'expiration';
+  transactionBlockhash: Blockhash;
+  /**
+   * What is the amount of time between calls when checking if the transaction blockhash
+   * is still valid, in milliseconds.
+   */
+  blockhashValidityPollingTimeoutMs?: number;
+};
+
+export type NoTimeoutConfig = BaseConfig & {
+  type: 'none';
+};

--- a/lib/transactions/utils.ts
+++ b/lib/transactions/utils.ts
@@ -1,0 +1,71 @@
+import { Transaction, VersionedTransaction } from '@solana/web3.js';
+import base58 from 'bs58';
+
+import { log } from '../logger';
+
+export const getUnixTs = () => new Date().getTime() / 1000;
+
+/* eslint-disable no-promise-executor-return */
+export const sleep = async (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export const sleepWithController = async (ms: number, controller: AbortController) =>
+  new Promise<void>((resolve) => {
+    if (controller?.signal.aborted) {
+      resolve();
+    }
+
+    let timeoutId: NodeJS.Timeout;
+    const onAbort = () => {
+      log(`Received abort, removing abort listener for timeout = ${timeoutId}`);
+
+      clearTimeout(timeoutId);
+      controller?.signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+
+    if (controller?.signal.aborted) {
+      onAbort();
+    } else {
+      controller?.signal.addEventListener('abort', onAbort);
+
+      timeoutId = setTimeout(() => {
+        controller?.signal.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+    }
+  });
+
+export const abortableSleep = async (ms: number, controller?: AbortController) =>
+  !controller ? sleep(ms) : sleepWithController(ms, controller);
+
+export const tryInvokeAbort = (controller: AbortController) => {
+  if (!controller.signal.aborted) {
+    controller.abort();
+  }
+};
+
+export const getTransactionSignatureOrThrow = (
+  transaction: Transaction | VersionedTransaction,
+): string => {
+  if (transaction.signatures.length === 0) {
+    throw new Error('Transaction does not have any signatures');
+  }
+
+  const signatureBuffer =
+    transaction.signatures[0] instanceof Uint8Array
+      ? Buffer.from(transaction.signatures[0])
+      : transaction.signatures[0].signature;
+  if (!signatureBuffer) throw new Error('Invalid signature');
+
+  return base58.encode(Buffer.from(signatureBuffer));
+};
+
+export const getTransactionSignature = (
+  transaction: Transaction | VersionedTransaction,
+): string | undefined => {
+  try {
+    return getTransactionSignatureOrThrow(transaction);
+  } catch (err: any) {
+    return undefined;
+  }
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -42,11 +42,23 @@ export const validateType = async (type: InstructionFieldTypes, value?: string) 
 
 export const toScientificNotation = (number: number, decimalPlaces: number) =>
   // Convert number to scientific notation with specified decimal places
-   number.toExponential(decimalPlaces);
+  number.toExponential(decimalPlaces);
 
 export const toCompactNumber = (number: any) => {
   const value = Number(number);
   if (Number.isNaN(value)) return Number(0.0);
   // Convert number to compact form 123,000,000 becomes 123M
-  return new Intl.NumberFormat('en', { notation: 'compact', maximumSignificantDigits: 4 }).format(value);
+  return new Intl.NumberFormat('en', { notation: 'compact', maximumSignificantDigits: 4 }).format(
+    value,
+  );
+};
+
+export const parsePossibleBoolean = (value?: string): boolean | undefined => {
+  if (value === undefined) return undefined;
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue === 'true' || normalizedValue === '1') return true;
+  if (normalizedValue === 'false' || normalizedValue === '0') return false;
+
+  return undefined;
 };


### PR DESCRIPTION
🚧  Logic should be ready for review, pending PR description & info

Minimum required code to invoke send and confirm a transaction (with defaults applied) 🙂 Otherwise, caller can pretty specifically define a variety of behaviors in both send and confirm logic.

```typescript
// assume connection and tx are previously defined
const signature = await sendAndConfirmTransaction({
  signedTransaction: tx,
  connection,
});
```

Associated with the following FaaS task: https://github.com/orgs/metaDAOproject/projects/11?pane=issue&itemId=55984929
