### PR TITLE
Add ability for custom swap API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ See Meta-DAO's repo for more details.
 ## Contributing
 
 You can find instructions and guidelines on how to contribute in [CONTRIBUTING.md](/CONTRIBUTING.md)
+
+## Using custom Swap API endpoints
+
+You can get Swap API urls from [Jupiter Station](https://station.jup.ag/docs/apis/swap-api), [QuickNode](https://marketplace.quicknode.com/add-on/metis-jupiter-v6-swap-api) or [JupiterAPI.com](https://www.jupiterapi.com/). You can adjust the `basePath` for `createJupiterApiClient` to your preference.

--- a/components/Proposals/JupSwapCard.tsx
+++ b/components/Proposals/JupSwapCard.tsx
@@ -17,7 +17,9 @@ export function JupSwapCard() {
   const [inAmount, setInAmount] = useState<number>(1);
   const [outAmount, setOutAmount] = useState<number>();
   const [isSwapping, setIsSwapping] = useState(false);
-  const jupiterQuoteApi = createJupiterApiClient();
+  const jupiterQuoteApi = createJupiterApiClient({
+    basePath: 'https://public.jupiterapi.com',
+  });
   const sender = useTransactionSender();
 
   if (!daoTokens || !daoTokens.baseToken || !daoTokens.quoteToken) return <Loader />;

--- a/hooks/useFetchSpotPrice.ts
+++ b/hooks/useFetchSpotPrice.ts
@@ -18,7 +18,7 @@ export function useFetchSpotPrice() {
     tokenName = 'FUTURE';
   }
   const url =
-    `https://quote-api.jup.ag/v6/quote?inputMint=${inputMint}&` +
+    `https://public.jupiterapi.com/quote?inputMint=${inputMint}&` +
     'outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&' +
     `amount=${tokenBase.toString()}&` +
     'slippageBps=50&' +


### PR DESCRIPTION
This PR adjusts the default API used for swap/price to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small fee on swaps given the stability/rate limits/new markets it provides. More details can be found on their site.

I also updated the README.md to provide options to other endpoints in case higher rate limits are needed.